### PR TITLE
SSHKey fingerprint handling

### DIFF
--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -100,8 +100,8 @@ func (key Key) MarshalAuthorizedKey() []byte {
 	return data.Bytes()
 }
 
-//Fingerprint returns the SH256 has of the fingerprint
-//base64 url encoded without a "SHA256:" prefix to be
+//Fingerprint returns the SHA256 hash of the fingerprint
+//base64 standard encoded without a "SHA256:" prefix to be
 //compatible with gin-auth
 func (key Key) Fingerprint() (string, error) {
 	sha := sha256.New()
@@ -110,6 +110,6 @@ func (key Key) Fingerprint() (string, error) {
 		return "", err
 	}
 
-	fingerprint := base64.RawURLEncoding.EncodeToString(sha.Sum(nil))
+	fingerprint := base64.StdEncoding.EncodeToString(sha.Sum(nil))
 	return fingerprint, nil
 }

--- a/store/ginauth.go
+++ b/store/ginauth.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/G-Node/gin-repo/auth"
@@ -25,7 +26,9 @@ func close(b io.ReadCloser) {
 
 func (store *GinAuthStore) LookupUserBySSH(fingerprint string) (*User, error) {
 
-	address := fmt.Sprintf("%s/api/keys/%s", store.URL, fingerprint)
+	q := &url.Values{}
+	q.Set("fingerprint", fingerprint)
+	address := fmt.Sprintf("%s/api/keys?%s", store.URL, q.Encode())
 	res, err := http.Get(address)
 
 	if err != nil {


### PR DESCRIPTION
Depends on gin-auth pull request [#92](https://github.com/G-Node/gin-auth/pull/92).

- Removes SSH key fingerprint from URL hierarchical part and adds it as URL query part.
- Switches fingerprint from base64 urlencoding to base64 stdencoding.