### PR TITLE
Test gin-shell via a docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
 
 before_install:
   - sudo apt-get update
+  - sudo apt-get install git-annex
   - sudo apt-get install python3-pip
   - pip3 install pyyaml
   - pushd contrib && ./hostkey.sh && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: go
+sudo: required
+
+services:
+  - docker
 
 go:
   - 1.7
   - tip
+
+before_install:
+  - docker build -t gin-repod .
 
 install:
   - go get "github.com/docopt/docopt-go"
@@ -11,3 +18,4 @@ install:
   - go get "github.com/gorilla/handlers"
   - go get "github.com/dgrijalva/jwt-go"
   - go get "golang.org/x/crypto/ssh"
+  - go get "github.com/fsouza/go-dockerclient"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 sudo: required
+dist: trusty
 
 services:
   - docker
@@ -9,6 +10,9 @@ go:
   - tip
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install python3-pip
+  - pip3 install pyyaml
   - pushd contrib && ./hostkey.sh && popd
   - docker build -t gin-repod .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.6
+  - 1.7
   - tip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
   - tip
 
 before_install:
+  - pushd contrib && ./hostkey.sh && popd
   - docker build -t gin-repod .
 
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir /var/run/sshd && chmod 755 /var/run/sshd
 
 # use supervisord to start sshd and gin-repod
 COPY ./contrib/supervisord.conf /etc/supervisord.conf
-EXPOSE 22 8888
+EXPOSE 22 8082
 CMD ["supervisord", "-c/etc/supervisord.conf"]
 
 RUN mkdir -p $GOPATH/src/github.com/G-Node/gin-repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update &&                                   \
                        python-pip python-setuptools     \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install supervisor
+RUN pip install supervisor pyyaml
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,12 @@ RUN mkdir /var/run/sshd && chmod 755 /var/run/sshd
 # use supervisord to start sshd and gin-repod
 COPY ./contrib/supervisord.conf /etc/supervisord.conf
 EXPOSE 22 8082
-CMD ["supervisord", "-c/etc/supervisord.conf"]
 
+# main startup script
+ADD ./contrib/main.sh /usr/local/bin/main.sh
+CMD ["/usr/local/bin/main.sh"]
+
+# now add the source, compile, install
 RUN mkdir -p $GOPATH/src/github.com/G-Node/gin-repo
 WORKDIR $GOPATH/src/github.com/G-Node/gin-repo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,6 @@ COPY ./contrib/supervisord.conf /etc/supervisord.conf
 EXPOSE 22 8888
 CMD ["supervisord", "-c/etc/supervisord.conf"]
 
-# To provision client keys for testing uncomment
-#  the following line:
-# COPY ./contrib/*.rsa* /data/
-
 RUN mkdir -p $GOPATH/src/github.com/G-Node/gin-repo
 WORKDIR $GOPATH/src/github.com/G-Node/gin-repo
 
@@ -55,3 +51,4 @@ RUN go install -v ./...
 
 RUN chown -R git:git /data
 WORKDIR /data
+VOLUME /data

--- a/cmd/gin-shell/main_test.go
+++ b/cmd/gin-shell/main_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	tmpdir := os.TempDir()
+	tmpdir := "/tmp"
 	datadir := filepath.Join(tmpdir, "grd-data")
 	err := os.MkdirAll(datadir, 0755)
 

--- a/cmd/gin-shell/main_test.go
+++ b/cmd/gin-shell/main_test.go
@@ -93,6 +93,7 @@ func TestMain(m *testing.M) {
 				{HostIP: "0.0.0.0", HostPort: "8082"},
 			},
 		},
+		Binds: []string{fmt.Sprintf("%s:/data", datadir)},
 	}
 
 	opts := docker.CreateContainerOptions{
@@ -113,8 +114,6 @@ func TestMain(m *testing.M) {
 	res := 1
 	var done time.Time
 	fmt.Fprintf(os.Stderr, "Container id: %q\n", c.ID)
-
-	hcfg.Binds = []string{fmt.Sprintf("%s:/data", datadir)}
 
 	err = dkr.StartContainer(c.ID, hcfg)
 	if err != nil {

--- a/cmd/gin-shell/main_test.go
+++ b/cmd/gin-shell/main_test.go
@@ -194,6 +194,24 @@ func TestMain(m *testing.M) {
 	//Now lets get on with the tests
 	res = m.Run()
 
+	if res != 0 {
+		fmt.Fprintf(os.Stdout, "Container logs:\n")
+		err = dkr.Logs(docker.LogsOptions{
+			Container:    c.ID,
+			OutputStream: os.Stdout,
+			ErrorStream:  os.Stderr,
+			Stdout:       true,
+			Stderr:       true,
+
+			Follow: false,
+		})
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not get container logs: %s", err)
+		}
+		fmt.Fprintf(os.Stdout, "---- EOF ----\n")
+	}
+
 	//tear down
 	if err = dkr.StopContainer(c.ID, 2000); err != nil {
 		fmt.Fprintf(os.Stderr, "cannot stop container: %s", err)

--- a/cmd/gin-shell/main_test.go
+++ b/cmd/gin-shell/main_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -18,12 +17,8 @@ import (
 var aliceKey []byte
 
 func TestSSHLogin(t *testing.T) {
-	key, err := ioutil.ReadFile("/tmp/grd-data/users/alice/alice.ssh.key")
-	if err != nil {
-		t.Fatalf("unable to read private key: %v", err)
-	}
 
-	signer, err := ssh.ParsePrivateKey(key)
+	signer, err := ssh.ParsePrivateKey(aliceKey)
 	if err != nil {
 		t.Fatalf("unable to parse private key: %v", err)
 	}

--- a/cmd/gin-shell/main_test.go
+++ b/cmd/gin-shell/main_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -70,64 +68,12 @@ func TestSSHLogin(t *testing.T) {
 	fmt.Fprintf(os.Stderr, "SSH: %q\n", e.String())
 }
 
-func FindContrib() (string, error) {
-	dir, err := os.Getwd()
-
-	if err != nil {
-		return "", nil
-	}
-
-	for {
-		cd := filepath.Join(dir, "contrib")
-		fmt.Fprintf(os.Stderr, "checking %q\n", cd)
-		_, err := os.Stat(cd)
-
-		if err == nil {
-			return cd, nil
-		} else if dir == "." || dir == "/" {
-			return "", fmt.Errorf("Could not find %q in hierarchy", "contrib")
-		}
-
-		dir = filepath.Dir(dir)
-	}
-}
-
 func TestMain(m *testing.M) {
 	flag.Parse()
 
 	if testing.Short() {
 		fmt.Fprintf(os.Stderr, "test relying on data/docker skipped\n")
 		os.Exit(0)
-	}
-
-	tmpdir := "/tmp"
-	datadir := filepath.Join(tmpdir, "grd-data")
-	err := os.MkdirAll(datadir, 0755)
-
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not create tmp dir: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Fprintf(os.Stderr, "[D] using : %q\n", datadir)
-	contrib, err := FindContrib()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not find contrib dir!\n")
-		os.Exit(1)
-	}
-
-	mkdata := filepath.Join(contrib, "mkdata.py")
-	datafile := filepath.Join(contrib, "data.yml")
-
-	cmd := exec.Command(mkdata, datafile)
-	cmd.Dir = datadir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err = cmd.Run()
-
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not run mkdata: %v\n", err)
-		os.Exit(1)
 	}
 
 	// now the container fun!

--- a/cmd/gin-shell/main_test.go
+++ b/cmd/gin-shell/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorks(t *testing.T) {
+	t.Logf("Seems working!")
+}
+
+func FindContrib() (string, error) {
+	dir, err := os.Getwd()
+
+	if err != nil {
+		return "", nil
+	}
+
+	for {
+		cd := filepath.Join(dir, "contrib")
+		fmt.Fprintf(os.Stderr, "checking %q\n", cd)
+		_, err := os.Stat(cd)
+
+		if err == nil {
+			return cd, nil
+		} else if dir == "." || dir == "/" {
+			return "", fmt.Errorf("Could not find %q in hierarchy", "contrib")
+		}
+
+		dir = filepath.Dir(dir)
+	}
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if testing.Short() {
+		fmt.Fprintf(os.Stderr, "test relying on data/docker skipped\n")
+		os.Exit(0)
+	}
+
+	tmpdir := os.TempDir()
+	datadir := filepath.Join(tmpdir, "grd-data")
+	err := os.MkdirAll(datadir, 0755)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not create tmp dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "[D] using : %q\n", datadir)
+	contrib, err := FindContrib()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not find contrib dir!\n")
+		os.Exit(1)
+	}
+
+	mkdata := filepath.Join(contrib, "mkdata.py")
+	datafile := filepath.Join(contrib, "data.yml")
+
+	cmd := exec.Command(mkdata, datafile)
+	cmd.Dir = datadir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not run mkdata: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/cmd/gin-shell/main_test.go
+++ b/cmd/gin-shell/main_test.go
@@ -146,13 +146,14 @@ func TestMain(m *testing.M) {
 				{HostIP: "0.0.0.0", HostPort: "8082"},
 			},
 		},
-		Binds: []string{fmt.Sprintf("%s:/data", datadir)},
+		//Binds: []string{fmt.Sprintf("%s:/data", datadir)},
 	}
 
 	opts := docker.CreateContainerOptions{
 		Config: &docker.Config{
 			Image:        "gin-repod",
 			ExposedPorts: map[docker.Port]struct{}{"22/tcp": {}, "8082/tcp": {}},
+			Env:          []string{"GRD_GENDATA=1"},
 			//Volumes:      map[string]struct{}{"/data": {}},
 		},
 		HostConfig: hcfg,

--- a/contrib/gin_ssh.sh
+++ b/contrib/gin_ssh.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+#Use with GIT_SSH=gin_ss.sh git clone git@github.com:/user/repo
+
+ssh -i "$GIN_SSHID" -p "$GIN_SSHPORT" -oStrictHostKeyChecking=no $1 $2

--- a/contrib/main.sh
+++ b/contrib/main.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+#Ensure we have the right permissions on /data
+find . -perm 0444 -exec chmod 0666 {} \; -exec chown git:git {} \; -exec chmod 0444 {} \;
+chown -Rf git:git /data
+supervisord -c/etc/supervisord.conf

--- a/contrib/main.sh
+++ b/contrib/main.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-#Ensure we have the right permissions on /data
-find . -perm 0444 -exec chmod 0666 {} \; -exec chown git:git {} \; -exec chmod 0444 {} \;
-chown -Rf git:git /data
+echo "Starting gin-repo service"
+echo " GRD_GENDATA=${GRD_GENDATA}"
+
+if [ ! -z ${GRD_GENDATA+x} ]; then
+    git config --global user.name "gin repo docker"
+    git config --global user.email "gin-repo@g-node.org"
+    DATA=${GRD_DATAFILE:-$GOPATH/src/github.com/G-Node/gin-repo/contrib/data.yml}
+    echo "Generating data [$DATA]"
+    $GOPATH/src/github.com/G-Node/gin-repo/contrib/mkdata.py $DATA
+fi
+
 supervisord -c/etc/supervisord.conf

--- a/contrib/mkdata.py
+++ b/contrib/mkdata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # coding=utf-8
 
 """ Generate a sample data structure to be used by
@@ -44,7 +44,7 @@ def make_repo(repo):
         pwd = os.getcwd()
         cmd = repo["generate"]
         args = shlex.split(cmd)
-        exepath = os.path.dirname(sys.argv[0])
+        exepath = os.path.abspath(os.path.dirname(sys.argv[0]))
         args[0] = os.path.join(exepath, args[0])
         os.chdir(tempdir)
         subprocess.check_call(args)
@@ -80,7 +80,7 @@ def create_repo(user, repo):
     os.mkdir(gindir)
     if repo.get("public") is not None:
         target = os.path.join(gindir, "public")
-        os.open(target, flags=os.O_CREAT)
+        open(target, "w")
     shared = repo.get("shared") or {}
     for buddy, level in shared.items():
         sharing = os.path.join(gindir, "sharing")

--- a/contrib/sshd_config
+++ b/contrib/sshd_config
@@ -2,5 +2,5 @@ Port 22
 AddressFamily inet
 HostKey /etc/ssh/ssh_host_rsa_key
 UsePrivilegeSeparation yes
-AuthorizedKeysCommand /go/bin/gin-shell --keys %k
+AuthorizedKeysCommand /go/bin/gin-shell --keys %u "%t %k"
 AuthorizedKeysCommandUser git


### PR DESCRIPTION
To test gin-shell we will do the following:

- Create a container with gin-repo
- Start container
- Generate test data in container (setting `GRD_GENDATA=1` env)
- Wait for http to respond (i.e. test data generation is done)
- Extract the private key for `alice` from the container
- Use alice's key to connect to container via ssh
- For now, ensure we cannot execute commands (i.e. `/usr/bin/whoami`)