### PR TITLE
Add support for browsing repositories.

### DIFF
--- a/cmd/gin-repod/main.go
+++ b/cmd/gin-repod/main.go
@@ -206,30 +206,6 @@ func (s *Server) SetupStores() {
 	}
 }
 
-func (s *Server) SetupRoutes() {
-	r := s.Root
-
-	r.HandleFunc("/intern/user/lookup", s.lookupUser).Methods("GET")
-	r.HandleFunc("/intern/repos/access", s.repoAccess).Methods("POST")
-
-	r.HandleFunc("/intern/hooks/pre-receive", s.hookPreReceive).Methods("POST")
-	r.HandleFunc("/intern/hooks/update", s.hookUpdate).Methods("POST")
-	r.HandleFunc("/intern/hooks/post-receive", s.hookPostReceive).Methods("POST")
-
-	r.HandleFunc("/repos/public", s.listPublicRepos).Methods("GET")
-	r.HandleFunc("/repos/shared", s.listSharedRepos).Methods("GET")
-
-	r.HandleFunc("/users/{user}/repos", s.createRepo).Methods("POST")
-	r.HandleFunc("/users/{user}/repos", s.listRepos).Methods("GET")
-
-	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.getRepoVisibility).Methods("GET")
-	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.setRepoVisibility).Methods("PUT")
-
-	r.HandleFunc("/users/{user}/repos/{repo}/branches/{branch}", s.getBranch).Methods("GET")
-
-	r.HandleFunc("/users/{user}/repos/{repo}/objects/{object}", s.getObject).Methods("GET")
-}
-
 func (s *Server) ListenAndServe() error {
 	s.log(INFO, "Listening on %s", s.Addr)
 	err := s.Server.ListenAndServe()

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -441,6 +441,10 @@ func (s *Server) getObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.objectToWire(w, repo, obj)
+}
+
+func (s *Server) objectToWire(w http.ResponseWriter, repo *git.Repository, obj git.Object) {
 	out := bufio.NewWriter(w)
 	switch obj := obj.(type) {
 	case *git.Commit:
@@ -513,7 +517,7 @@ func (s *Server) getObject(w http.ResponseWriter, r *http.Request) {
 			n = m
 		}
 		buf := make([]byte, n)
-		_, err = obj.Read(buf[:])
+		_, err := obj.Read(buf[:])
 		if err != nil {
 			panic("IO error")
 		}
@@ -521,7 +525,7 @@ func (s *Server) getObject(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", mtype)
 
 		w.Write(buf)
-		_, err := io.Copy(w, obj)
+		_, err = io.Copy(w, obj)
 		if err != nil {
 			s.log(WARN, "io error, but data already written")
 		}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -551,7 +551,7 @@ func (s *Server) browseRepo(w http.ResponseWriter, r *http.Request) {
 	ipath := ivars["path"]
 
 	//for now we only support master :(
-	if err != nil || ibranch != "master" || ipath == "" {
+	if err != nil || ibranch != "master" {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/cmd/gin-repod/routes.go
+++ b/cmd/gin-repod/routes.go
@@ -1,0 +1,25 @@
+package main
+
+func (s *Server) SetupRoutes() {
+	r := s.Root
+
+	r.HandleFunc("/intern/user/lookup", s.lookupUser).Methods("GET")
+	r.HandleFunc("/intern/repos/access", s.repoAccess).Methods("POST")
+
+	r.HandleFunc("/intern/hooks/pre-receive", s.hookPreReceive).Methods("POST")
+	r.HandleFunc("/intern/hooks/update", s.hookUpdate).Methods("POST")
+	r.HandleFunc("/intern/hooks/post-receive", s.hookPostReceive).Methods("POST")
+
+	r.HandleFunc("/repos/public", s.listPublicRepos).Methods("GET")
+	r.HandleFunc("/repos/shared", s.listSharedRepos).Methods("GET")
+
+	r.HandleFunc("/users/{user}/repos", s.createRepo).Methods("POST")
+	r.HandleFunc("/users/{user}/repos", s.listRepos).Methods("GET")
+
+	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.getRepoVisibility).Methods("GET")
+	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.setRepoVisibility).Methods("PUT")
+
+	r.HandleFunc("/users/{user}/repos/{repo}/branches/{branch}", s.getBranch).Methods("GET")
+
+	r.HandleFunc("/users/{user}/repos/{repo}/objects/{object}", s.getObject).Methods("GET")
+}

--- a/cmd/gin-repod/routes.go
+++ b/cmd/gin-repod/routes.go
@@ -20,6 +20,6 @@ func (s *Server) SetupRoutes() {
 	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.setRepoVisibility).Methods("PUT")
 
 	r.HandleFunc("/users/{user}/repos/{repo}/branches/{branch}", s.getBranch).Methods("GET")
-
 	r.HandleFunc("/users/{user}/repos/{repo}/objects/{object}", s.getObject).Methods("GET")
+	r.HandleFunc("/users/{user}/repos/{repo}/browse/{branch}/{path:.*}", s.browseRepo).Methods("GET")
 }

--- a/cmd/gin-repod/routes.go
+++ b/cmd/gin-repod/routes.go
@@ -21,5 +21,6 @@ func (s *Server) SetupRoutes() {
 
 	r.HandleFunc("/users/{user}/repos/{repo}/branches/{branch}", s.getBranch).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/objects/{object}", s.getObject).Methods("GET")
+	r.HandleFunc("/users/{user}/repos/{repo}/browse/{branch}", s.browseRepo).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/browse/{branch}/{path:.*}", s.browseRepo).Methods("GET")
 }

--- a/git/annex.go
+++ b/git/annex.go
@@ -144,7 +144,7 @@ func (repo *Repository) Astat(target string) (*AnnexStat, error) {
 	p := filepath.Join(repo.Path, "annex", "objects", ki.HashDirLower(), ki.Key, ki.Key)
 	fi, err := os.Stat(p)
 
-	if err != nil {
+	if err == nil {
 		sbuf.Have = true
 		sbuf.Size = fi.Size()
 	} else if os.IsNotExist(err) {

--- a/git/repo.go
+++ b/git/repo.go
@@ -259,8 +259,6 @@ func (repo *Repository) Readlink(id SHA1) (string, error) {
 //for the file tree starting in the node root.
 //The root object can be either a Commit, Tree or Tag.
 func (repo *Repository) ObjectForPath(root Object, pathstr string) (Object, error) {
-	cleaned := path.Clean(strings.Trim(pathstr, " /"))
-	comps := strings.Split(cleaned, "/")
 
 	var node Object
 	var err error
@@ -279,6 +277,9 @@ func (repo *Repository) ObjectForPath(root Object, pathstr string) (Object, erro
 	if err != nil {
 		return nil, fmt.Errorf("could not root tree object: %v", err)
 	}
+
+	cleaned := path.Clean(strings.Trim(pathstr, " /"))
+	comps := strings.Split(cleaned, "/")
 
 	var i int
 	for i = 0; i < len(comps); i++ {

--- a/git/repo.go
+++ b/git/repo.go
@@ -295,6 +295,13 @@ func (repo *Repository) ObjectForPath(root Object, pathstr string) (Object, erro
 			return nil, err
 		}
 
+		//Since we call path.Clean(), this should really
+		//only happen at the root, but it is safe to
+		//have here anyway
+		if comps[i] == "." || comps[i] == "/" {
+			continue
+		}
+
 		var id *SHA1
 		for tree.Next() {
 			entry := tree.Entry()

--- a/git/repo_test.go
+++ b/git/repo_test.go
@@ -119,6 +119,8 @@ var ofptests = []struct {
 	err   bool
 }{
 	// 9c3409e9225137bcccf070e1bb583b808da37003 is a commit object
+	{"9c3409e9225137bcccf070e1bb583b808da37003", "/", ObjTree, false},                 // the root
+	{"9c3409e9225137bcccf070e1bb583b808da37003", "", ObjTree, false},                  // the root
 	{"9c3409e9225137bcccf070e1bb583b808da37003", "/git/repo_test.go", ObjBlob, false}, // this is us!
 	{"9c3409e9225137bcccf070e1bb583b808da37003", "/git", ObjTree, false},              // our parent dir
 	{"9c3409e9225137bcccf070e1bb583b808da37003", "/cmd/gin-shell/main.go", ObjBlob, false},


### PR DESCRIPTION
Also moves routes specification to a `routes.go` file.
Fixes a bad bug in the annex stat code.
Adds support for getting the root of the tree in ObjectForPath.