### PR TITLE
Refactor Repository Visibility

### DIFF
--- a/cmd/gin-repod/main_test.go
+++ b/cmd/gin-repod/main_test.go
@@ -58,7 +58,7 @@ func NewGet(t *testing.T, url string, user string) *http.Request {
 	if user != "" {
 		token, err = server.users.TokenForUser(user)
 		if err != nil {
-			t.Fatalf("could not make token for alice: %v", token)
+			t.Fatalf("could not make token for %q: %v, %v", user, token, err)
 		}
 	}
 

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -90,7 +90,6 @@ func (s *Server) createRepo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) repoToWire(id store.RepoId, repo *git.Repository) (wire.Repo, error) {
-
 	public, err := s.repos.GetRepoVisibility(id)
 	if err != nil {
 		s.log(WARN, "could not get repo visibility: %v", err)
@@ -102,7 +101,7 @@ func (s *Server) repoToWire(id store.RepoId, repo *git.Repository) (wire.Repo, e
 		Owner:       id.Owner,
 		Description: repo.ReadDescription(),
 		Head:        "master",
-		Visibility:  public,
+		Public:      public,
 	}
 
 	return wr, nil

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -316,11 +316,7 @@ func (s *Server) getRepoVisibility(w http.ResponseWriter, r *http.Request) {
 
 	public, err := s.repos.GetRepoVisibility(rid)
 	if err != nil {
-		if os.IsNotExist(err) {
-			w.WriteHeader(http.StatusNotFound)
-		} else {
-			w.WriteHeader(http.StatusBadRequest)
-		}
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -320,16 +320,9 @@ func (s *Server) getRepoVisibility(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var visibility string
-	if public {
-		visibility = "public"
-	} else {
-		visibility = "private"
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(fmt.Sprintf("{%q: %q}", "visibility", visibility)))
+	w.Write([]byte(fmt.Sprintf("{%q: %t}", "Public", public)))
 }
 
 func (s *Server) setRepoVisibility(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -300,6 +300,15 @@ func (s *Server) getRepoVisibility(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Return StatusBadRequest if an error occurs or if the repository does not exist.
+	// Returning StatusNotFound for non existing repositories could lead to inference
+	// of private repositories later on.
+	exists, err := s.repos.RepoExists(rid)
+	if err != nil || !exists {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	_, ok := s.checkAccess(w, r, rid, store.PullAccess)
 	if !ok {
 		return

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -3,19 +3,18 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
-
-	"github.com/gorilla/mux"
-
 	"regexp"
 
 	"github.com/G-Node/gin-repo/git"
 	"github.com/G-Node/gin-repo/store"
 	"github.com/G-Node/gin-repo/wire"
+	"github.com/gorilla/mux"
 )
 
 var nameChecker *regexp.Regexp
@@ -278,13 +277,18 @@ func (s *Server) listPublicRepos(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// varsToRepoID checks if a map contains the entries "user" and "repo" and
+// returns them as a store.RepoId or an error if they are missing.
 func (s *Server) varsToRepoID(vars map[string]string) (store.RepoId, error) {
 	iuser := vars["user"]
 	irepo := vars["repo"]
 
-	//TODO: check name and stuff
+	repoId := store.RepoId{iuser, irepo}
+	if iuser == "" || irepo == "" {
+		return repoId, errors.New("Missing arguments.")
+	}
 
-	return store.RepoId{iuser, irepo}, nil
+	return repoId, nil
 }
 
 func (s *Server) getRepoVisibility(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -389,7 +389,9 @@ func (s *Server) setRepoVisibility(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//TODO: return the visibility
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(fmt.Sprintf("{%q: %t}", "Public", setPublic)))
 }
 
 func (s *Server) getBranch(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/G-Node/gin-repo/store"
+)
+
+const repoUser = "alice"
+const repoName = "exrepo"
+const defaultRepoHead = "master"
+
+func TestRepoToWire(t *testing.T) {
+
+	id := store.RepoId{repoUser, repoName}
+
+	repo, err := server.repos.OpenGitRepo(id)
+	if err != nil {
+		t.Fatalf("Error fetching repository %v: %v\n", id, err)
+	}
+
+	wired, err := server.repoToWire(id, repo)
+	if err != nil {
+		t.Fatalf("Error wiring repository settings: %v\n", err)
+	}
+
+	if wired.Name != repoName {
+		t.Errorf("Expected repository name to be %q but was %q\n", repoName, wired.Name)
+	}
+	if wired.Owner != repoUser {
+		t.Errorf("Expected repository owner to be %q but was %q\n", repoUser, wired.Owner)
+	}
+	if wired.Description == "" {
+		t.Error("Expected repository description but got empty field")
+	}
+	if wired.Visibility {
+		t.Errorf("Expected repository privacy setting to be false but was: %t\n", wired.Visibility)
+	}
+	if wired.Head != defaultRepoHead {
+		t.Errorf("Expected repository head to be %q but got %q\n", defaultRepoHead, wired.Head)
+	}
+}

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -40,3 +40,42 @@ func TestRepoToWire(t *testing.T) {
 		t.Errorf("Expected repository head to be %q but got %q\n", defaultRepoHead, wired.Head)
 	}
 }
+
+func Test_varsToRepoID(t *testing.T) {
+	const user = "userName"
+	const repo = "repoName"
+
+	// test missing arguments
+	vars := make(map[string]string)
+	_, err := server.varsToRepoID(vars)
+	if err == nil {
+		t.Fatal("Expected error on missing arguments.")
+	}
+	// test missing user
+	vars["repo"] = repo
+	_, err = server.varsToRepoID(vars)
+	if err == nil {
+		t.Fatal("Expected error on missing user.")
+	}
+
+	// test missing repository
+	delete(vars, "repo")
+	vars["user"] = user
+	_, err = server.varsToRepoID(vars)
+	if err == nil {
+		t.Fatal("Expected error on missing repository.")
+	}
+
+	// test existing user and repository
+	vars["repo"] = repo
+	id, err := server.varsToRepoID(vars)
+	if err != nil {
+		t.Fatalf("Error on exising user and repository: %v\n", err)
+	}
+	if id.Owner != user {
+		t.Fatalf("Expected user %q, but got %q\n", user, id.Owner)
+	}
+	if id.Name != repo {
+		t.Fatalf("Expected repository %q but got %q\n", repo, id.Name)
+	}
+}

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -33,8 +33,8 @@ func TestRepoToWire(t *testing.T) {
 	if wired.Description == "" {
 		t.Error("Expected repository description but got empty field")
 	}
-	if wired.Visibility {
-		t.Errorf("Expected repository privacy setting to be false but was: %t\n", wired.Visibility)
+	if wired.Public {
+		t.Errorf("Expected repository public setting to be false but was: %t\n", wired.Public)
 	}
 	if wired.Head != defaultRepoHead {
 		t.Errorf("Expected repository head to be %q but got %q\n", defaultRepoHead, wired.Head)

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -307,9 +307,21 @@ func Test_setRepoVisibility(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusOK)
+	resp, err := makeRequest(t, req, http.StatusOK)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	var visibility struct {
+		Public bool
+	}
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&visibility)
+	if err != nil {
+		t.Fatalf("Error decoding response: %v\n", err)
+	}
+	if visibility.Public {
+		t.Fatalf("Expected public false for repository %s\n", validPublicRepo)
 	}
 
 	check, err = server.repos.GetRepoVisibility(rid)

--- a/contrib/rest.http
+++ b/contrib/rest.http
@@ -69,5 +69,5 @@ Authorization: Bearer :token
 Content-Type: application/json
 
 {
-        "visibility": "public"
+        "public": true
 }

--- a/store/repo.go
+++ b/store/repo.go
@@ -112,6 +112,20 @@ func (store *RepoStore) idToPath(id RepoId) string {
 	return filepath.Join(store.gitPath(), id.Owner, id.Name+".git")
 }
 
+// RepoExists returns true if the path to a provided RepoId exists, false otherwise.
+func (store *RepoStore) RepoExists(id RepoId) (bool, error) {
+	repoPath := store.idToPath(id)
+	_, err := os.Stat(repoPath)
+
+	if err != nil && os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (store *RepoStore) CreateRepo(id RepoId) (*git.Repository, error) {
 	path := store.idToPath(id)
 

--- a/store/repo_test.go
+++ b/store/repo_test.go
@@ -105,3 +105,60 @@ func TestMain(m *testing.M) {
 	_ = os.Chdir(cwd)
 	os.Exit(res)
 }
+
+func Test_RepoExists(t *testing.T) {
+	const invalidUser = "iDoNotExist"
+	const invalidRepo = "iDoNotExist"
+	const validUser = "alice"
+	const validRepo = "auth"
+
+	// Test empty RepoId
+	id := RepoId{"", ""}
+	exists, err := repos.RepoExists(id)
+	if err != nil {
+		t.Fatalf("Unexpected error on empty RepoId: %v\n", err)
+	}
+	if exists {
+		t.Fatal("Did not expect true on empty RepoId.")
+	}
+
+	// Test invalid user
+	id = RepoId{invalidUser, ""}
+	exists, err = repos.RepoExists(id)
+	if err != nil {
+		t.Fatalf("Unexpected error on invalid user: %v\n", err)
+	}
+	if exists {
+		t.Fatal("Did not expect true on invalid user.")
+	}
+
+	// Test missing repo name with existing user
+	id = RepoId{validUser, ""}
+	exists, err = repos.RepoExists(id)
+	if err != nil {
+		t.Fatalf("Unexpected error on missing repo: %v\n", err)
+	}
+	if exists {
+		t.Fatal("Did not expect true on missing repo.")
+	}
+
+	// Test invalid repo name with existing user
+	id = RepoId{validUser, invalidRepo}
+	exists, err = repos.RepoExists(id)
+	if err != nil {
+		t.Fatalf("Unexpected error on invalid repo: %v\n", err)
+	}
+	if exists {
+		t.Fatal("Did not expect true on invalid repo.")
+	}
+
+	// Test valid user with valid repository
+	id = RepoId{validUser, validRepo}
+	exists, err = repos.RepoExists(id)
+	if err != nil {
+		t.Fatalf("Unexpected error on valid RepoId: %v\n", err)
+	}
+	if !exists {
+		t.Fatal("Did not expect false on valid RepoId.")
+	}
+}

--- a/store/repo_test.go
+++ b/store/repo_test.go
@@ -1,9 +1,16 @@
 package store
 
 import (
+	"fmt"
+	"os"
 	"reflect"
 	"testing"
+
+	"github.com/G-Node/gin-repo/internal/testbed"
 )
+
+var users UserStore
+var repos *RepoStore
 
 var defaultRepo = &RepoId{"foo", "bar"}
 
@@ -55,4 +62,46 @@ func TestParseRepoId(t *testing.T) {
 			t.Errorf("RepoIdParse(%q) => %v, want %v", tt.in, out, *tt.out)
 		}
 	}
+}
+
+// TestMain sets up a temporary user store for store method tests.
+// Currently the temporary files created by this function are not cleaned up.
+func TestMain(m *testing.M) {
+	repoDir, err := testbed.MkData("/tmp")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not make test data: %v\n", err)
+		os.Exit(1)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not get cwd: %v", err)
+		os.Exit(1)
+	}
+
+	// Change to repoDir is required, since creating a local user store depends on
+	// auth.ReadSharedSecret(), which reads a file "gin.secret" from the current directory
+	// and fails otherwise.
+	err = os.Chdir(repoDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not set cwd to repoDir: %v", err)
+		os.Exit(1)
+	}
+
+	users, err = NewUserStore(repoDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not create local user store: %v\n", err)
+		os.Exit(1)
+	}
+
+	repos, err = NewRepoStore(repoDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not create local repo store: %v\n", err)
+		os.Exit(1)
+	}
+
+	res := m.Run()
+
+	_ = os.Chdir(cwd)
+	os.Exit(res)
 }

--- a/wire/proto.go
+++ b/wire/proto.go
@@ -19,7 +19,7 @@ type Repo struct {
 	Name        string
 	Owner       string
 	Description string
-	Visibility  bool
+	Public      bool
 	Head        string
 }
 


### PR DESCRIPTION
Mainly addresses issue #41 and adds tests for functions and methods involved.

- Closes #41 - refactor repository visibility
- Closes #44 - remove unreachable statement
- Closes #45 - add repository exists check
- adds [store] TestMain for package store
- adds [store] TestRepoExist
- adds [cmd/repod] repo_test.go
- adds [cmd/repod] TestRepoToWire
- adds [cmd/repod] Test_varsToRepoID
- adds [cmd/repod] Test_getRepoVisibility
- adds [cmd/repod] Test_setRepoVisibility
- updates [contrib/rest.http] usage of setRepoVisibility