### PR TITLE
PATCH repository settings

### DIFF
--- a/cmd/gin-repod/auth.go
+++ b/cmd/gin-repod/auth.go
@@ -39,7 +39,7 @@ func (s *Server) checkAccess(w http.ResponseWriter, r *http.Request, rid store.R
 	s.log(DEBUG, "U: %s w: %v; h: %v -> %v", uid, want, have, want < have)
 	if want > have {
 
-		if have < store.PullAccess {
+		if have <= store.PullAccess {
 			//TODO: all 404 messages should be the same, otherwise you can infer information
 			// from them
 			http.Error(w, "Nothing here. Move along.", http.StatusNotFound)

--- a/cmd/gin-repod/auth.go
+++ b/cmd/gin-repod/auth.go
@@ -49,5 +49,11 @@ func (s *Server) checkAccess(w http.ResponseWriter, r *http.Request, rid store.R
 		return user, false
 	}
 
+	exists, err := s.repos.RepoExists(rid)
+	if err != nil || !exists {
+		http.Error(w, "Nothing here. Move along.", http.StatusNotFound)
+		return user, false
+	}
+
 	return user, true
 }

--- a/cmd/gin-repod/main.go
+++ b/cmd/gin-repod/main.go
@@ -253,7 +253,7 @@ Options:
 
 	s.Handler = handlers.CORS(
 		handlers.AllowedHeaders([]string{"Authorization", "Content-Type"}),
-		handlers.AllowedMethods([]string{"GET", "PUT", "POST", "DELETE"}),
+		handlers.AllowedMethods([]string{"GET", "PUT", "POST", "DELETE", "PATCH"}),
 	)(s.Handler)
 
 	// this call might never return if there actually was

--- a/cmd/gin-repod/main_test.go
+++ b/cmd/gin-repod/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -78,6 +79,27 @@ func makeRequest(req *http.Request, code int) (*httptest.ResponseRecorder, error
 	}
 
 	return rr, nil
+}
+
+func RunRequest(method string, url string, body io.Reader,
+	header map[string]string, code int) (*httptest.ResponseRecorder, error) {
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if header != nil && len(header) > 0 {
+		for k, v := range header {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := makeRequest(req, code)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func TestBranchAccess(t *testing.T) {

--- a/cmd/gin-repod/main_test.go
+++ b/cmd/gin-repod/main_test.go
@@ -95,11 +95,7 @@ func RunRequest(method string, url string, body io.Reader,
 		}
 	}
 
-	resp, err := makeRequest(req, code)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return makeRequest(req, code)
 }
 
 func TestBranchAccess(t *testing.T) {

--- a/cmd/gin-repod/main_test.go
+++ b/cmd/gin-repod/main_test.go
@@ -69,7 +69,7 @@ func NewGet(t *testing.T, url string, user string) *http.Request {
 	return req
 }
 
-func makeRequest(t *testing.T, req *http.Request, code int) (*httptest.ResponseRecorder, error) {
+func makeRequest(req *http.Request, code int) (*httptest.ResponseRecorder, error) {
 	rr := httptest.NewRecorder()
 	server.ServeHTTP(rr, req)
 
@@ -82,13 +82,13 @@ func makeRequest(t *testing.T, req *http.Request, code int) (*httptest.ResponseR
 
 func TestBranchAccess(t *testing.T) {
 	req := NewGet(t, "/users/alice/repos/exrepo/branches/master", "")
-	_, err := makeRequest(t, req, http.StatusNotFound)
+	_, err := makeRequest(req, http.StatusNotFound)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req = NewGet(t, "/users/alice/repos/exrepo/branches/master", "alice")
-	_, err = makeRequest(t, req, http.StatusOK)
+	_, err = makeRequest(req, http.StatusOK)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,13 +114,13 @@ func TestObjectAccess(t *testing.T) {
 	//now make some requests
 	url := fmt.Sprintf("/users/alice/repos/exrepo/objects/%s", id)
 	req := NewGet(t, url, "")
-	_, err = makeRequest(t, req, http.StatusNotFound)
+	_, err = makeRequest(req, http.StatusNotFound)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req = NewGet(t, url, "alice")
-	_, err = makeRequest(t, req, http.StatusOK)
+	_, err = makeRequest(req, http.StatusOK)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"regexp"
-	"strings"
 
 	"github.com/G-Node/gin-repo/git"
 	"github.com/G-Node/gin-repo/store"
@@ -294,25 +293,10 @@ func (s *Server) varsToRepoID(vars map[string]string) (store.RepoId, error) {
 }
 
 func (s *Server) getRepoVisibility(w http.ResponseWriter, r *http.Request) {
-	header := r.Header.Get("Authorization")
-	if header == "" || !strings.HasPrefix(header, "Bearer ") {
-		w.WriteHeader(http.StatusForbidden)
-		return
-	}
-
 	ivars := mux.Vars(r)
 	rid, err := s.varsToRepoID(ivars)
 
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	// Return StatusBadRequest if an error occurs or if the repository does not exist.
-	// Returning StatusNotFound for non existing repositories could lead to inference
-	// of private repositories later on.
-	exists, err := s.repos.RepoExists(rid)
-	if err != nil || !exists {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -334,25 +318,10 @@ func (s *Server) getRepoVisibility(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) setRepoVisibility(w http.ResponseWriter, r *http.Request) {
-	header := r.Header.Get("Authorization")
-	if header == "" || !strings.HasPrefix(header, "Bearer ") {
-		w.WriteHeader(http.StatusForbidden)
-		return
-	}
-
 	ivars := mux.Vars(r)
 	rid, err := s.varsToRepoID(ivars)
 
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	// Return StatusBadRequest if an error occurs or if the repository does not exist.
-	// Returning StatusNotFound for non existing repositories could lead to inference
-	// of private repositories later on.
-	exists, err := s.repos.RepoExists(rid)
-	if err != nil || !exists {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -650,25 +619,10 @@ func (s *Server) browseRepo(w http.ResponseWriter, r *http.Request) {
 // and a string as value, "public" as key and a boolean value as value or both.
 // A request that does not contain any of these two keys will result in a BadRequest status.
 func (s *Server) patchRepoSettings(w http.ResponseWriter, r *http.Request) {
-	header := r.Header.Get("Authorization")
-	if header == "" || !strings.HasPrefix(header, "Bearer ") {
-		w.WriteHeader(http.StatusForbidden)
-		return
-	}
-
 	ivars := mux.Vars(r)
 	rid, err := s.varsToRepoID(ivars)
 
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	// Return StatusBadRequest if an error occurs or if the repository does not exist.
-	// Returning StatusNotFound for non existing repositories could lead to inference
-	// of private repositories later on.
-	exists, err := s.repos.RepoExists(rid)
-	if err != nil || !exists {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -16,6 +16,7 @@ import (
 	"github.com/G-Node/gin-repo/store"
 	"github.com/G-Node/gin-repo/wire"
 	"github.com/gorilla/mux"
+	"strings"
 )
 
 var nameChecker *regexp.Regexp
@@ -632,10 +633,17 @@ func (s *Server) browseRepo(w http.ResponseWriter, r *http.Request) {
 }
 
 // patchRepoSettings patches repository description and public status.
+// The request header has to contain an authorization header with a valid token.
 // The request body has to contain valid JSON containing "description" as key
 // and a string as value, "public" as key and a boolean value as value or both.
 // A request that does not contain any of these two keys will result in a BadRequest status.
 func (s *Server) patchRepoSettings(w http.ResponseWriter, r *http.Request) {
+	header := r.Header.Get("Authorization")
+	if header == "" || !strings.HasPrefix(header, "Bearer ") {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
 	ivars := mux.Vars(r)
 	rid, err := s.varsToRepoID(ivars)
 

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -657,56 +657,54 @@ func (s *Server) patchRepoSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var respBody string
+	// TODO The following code currently does not deal with the problem
+	// if an error occurs, after part of the patch has already
+	// been applied.
+	responseCode := http.StatusOK
+
+	// The following code deviates from normal style of
+	// return on error, since we always want to return
+	// the latest state if the repository settings,
+	// even if an error occurs.
 	if patch.Description == nil && patch.Public == nil {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	} else if patch.Description != nil && patch.Public != nil {
-		err = s.repos.SetRepoVisibility(rid, *patch.Public)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		repo, err := git.OpenRepository(s.repos.IdToPath(rid))
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		err = repo.WriteDescription(*patch.Description)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		respBody = fmt.Sprintf("{%q: %t, %q: %q}", "public", *patch.Public, "description", *patch.Description)
-
-	} else if patch.Description != nil {
-		repo, err := git.OpenRepository(s.repos.IdToPath(rid))
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		err = repo.WriteDescription(*patch.Description)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		respBody = fmt.Sprintf("{%q: %q}", "description", *patch.Description)
-
-	} else if patch.Public != nil {
-		err = s.repos.SetRepoVisibility(rid, *patch.Public)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		respBody = fmt.Sprintf("{%q: %t}", "public", *patch.Public)
+		responseCode = http.StatusBadRequest
+	}
+	repository, err := git.OpenRepository(s.repos.IdToPath(rid))
+	if err != nil {
+		responseCode = http.StatusInternalServerError
 	}
 
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(respBody))
+	if patch.Description != nil {
+		err = repository.WriteDescription(*patch.Description)
+		if err != nil {
+			responseCode = http.StatusInternalServerError
+		}
+	}
+
+	if patch.Public != nil {
+		err = s.repos.SetRepoVisibility(rid, *patch.Public)
+		if err != nil {
+			responseCode = http.StatusInternalServerError
+		}
+	}
+
+	var resp struct {
+		Public      bool
+		Description string
+	}
+
+	resp.Description = repository.ReadDescription()
+	resp.Public, err = s.repos.GetRepoVisibility(rid)
+	if err != nil {
+		responseCode = http.StatusInternalServerError
+	}
+
+	respBody, err := json.Marshal(resp)
+	if err != nil {
+		responseCode = http.StatusInternalServerError
+	}
+
+	w.WriteHeader(responseCode)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(respBody)
 }

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -11,12 +11,12 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/G-Node/gin-repo/git"
 	"github.com/G-Node/gin-repo/store"
 	"github.com/G-Node/gin-repo/wire"
 	"github.com/gorilla/mux"
-	"strings"
 )
 
 var nameChecker *regexp.Regexp

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -294,6 +294,12 @@ func (s *Server) varsToRepoID(vars map[string]string) (store.RepoId, error) {
 }
 
 func (s *Server) getRepoVisibility(w http.ResponseWriter, r *http.Request) {
+	header := r.Header.Get("Authorization")
+	if header == "" || !strings.HasPrefix(header, "Bearer ") {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
 	ivars := mux.Vars(r)
 	rid, err := s.varsToRepoID(ivars)
 

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -630,3 +630,8 @@ func (s *Server) browseRepo(w http.ResponseWriter, r *http.Request) {
 
 	s.objectToWire(w, repo, obj)
 }
+
+// patchRepoSettings
+func (s *Server) patchRepoSettings(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -328,6 +328,12 @@ func (s *Server) getRepoVisibility(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) setRepoVisibility(w http.ResponseWriter, r *http.Request) {
+	header := r.Header.Get("Authorization")
+	if header == "" || !strings.HasPrefix(header, "Bearer ") {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
 	ivars := mux.Vars(r)
 	rid, err := s.varsToRepoID(ivars)
 

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -98,7 +98,7 @@ func Test_getRepoVisibility(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = makeRequest(t, req, http.StatusForbidden)
+	_, err = makeRequest(req, http.StatusForbidden)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func Test_getRepoVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "")
-	_, err = makeRequest(t, req, http.StatusForbidden)
+	_, err = makeRequest(req, http.StatusForbidden)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func Test_getRepoVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func Test_getRepoVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func Test_getRepoVisibility(t *testing.T) {
 		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func Test_getRepoVisibility(t *testing.T) {
 		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
-	resp, err := makeRequest(t, req, http.StatusOK)
+	resp, err := makeRequest(req, http.StatusOK)
 	if err != nil {
 		t.Fatalf("Unexpected error on public repository: %v\n", err)
 	}
@@ -190,7 +190,7 @@ func Test_getRepoVisibility(t *testing.T) {
 		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
-	resp, err = makeRequest(t, req, http.StatusOK)
+	resp, err = makeRequest(req, http.StatusOK)
 	if err != nil {
 		t.Fatalf("Unexpected error on public repository: %v\n", err)
 	}
@@ -228,7 +228,7 @@ func Test_setRepoVisibility(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = makeRequest(t, req, http.StatusForbidden)
+	_, err = makeRequest(req, http.StatusForbidden)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func Test_setRepoVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "")
-	_, err = makeRequest(t, req, http.StatusForbidden)
+	_, err = makeRequest(req, http.StatusForbidden)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func Test_setRepoVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +264,7 @@ func Test_setRepoVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +276,7 @@ func Test_setRepoVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(t, req, http.StatusForbidden)
+	_, err = makeRequest(req, http.StatusForbidden)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func Test_setRepoVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +301,7 @@ func Test_setRepoVisibility(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func Test_setRepoVisibility(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +327,7 @@ func Test_setRepoVisibility(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +353,7 @@ func Test_setRepoVisibility(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	resp, err := makeRequest(t, req, http.StatusOK)
+	resp, err := makeRequest(req, http.StatusOK)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +408,7 @@ func Test_patchRepoSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = makeRequest(t, req, http.StatusForbidden)
+	_, err = makeRequest(req, http.StatusForbidden)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +420,7 @@ func Test_patchRepoSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "")
-	_, err = makeRequest(t, req, http.StatusForbidden)
+	_, err = makeRequest(req, http.StatusForbidden)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func Test_patchRepoSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -444,7 +444,7 @@ func Test_patchRepoSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +456,7 @@ func Test_patchRepoSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func Test_patchRepoSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +481,7 @@ func Test_patchRepoSettings(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +494,7 @@ func Test_patchRepoSettings(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -507,7 +507,7 @@ func Test_patchRepoSettings(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusBadRequest)
+	_, err = makeRequest(req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func Test_patchRepoSettings(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusOK)
+	_, err = makeRequest(req, http.StatusOK)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -562,7 +562,7 @@ func Test_patchRepoSettings(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusOK)
+	_, err = makeRequest(req, http.StatusOK)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -588,7 +588,7 @@ func Test_patchRepoSettings(t *testing.T) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(t, req, http.StatusOK)
+	_, err = makeRequest(req, http.StatusOK)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -92,12 +92,36 @@ func Test_getRepoVisibility(t *testing.T) {
 	const validPublicRepo = "auth"
 	const validPrivateRepo = "exrepo"
 
-	// test request fail for non existing user
+	// test request fail for missing authorization header
 	url := fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = makeRequest(t, req, http.StatusForbidden)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test request fail for invalid authorization header
+	url = fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
+	req, err = http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Authorization", "")
+	_, err = makeRequest(t, req, http.StatusForbidden)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test request fail for non existing user w/o authorization
+	url = fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
+	req, err = http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Authorization", "Bearer ")
 	_, err = makeRequest(t, req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
@@ -109,6 +133,7 @@ func Test_getRepoVisibility(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("Authorization", "Bearer ")
 	_, err = makeRequest(t, req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -104,7 +104,7 @@ func Test_getRepoVisibility(t *testing.T) {
 
 	// test request fail for missing authorization header
 	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, nil, http.StatusForbidden)
+	_, err = RunRequest(method, url, nil, nil, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -112,7 +112,7 @@ func Test_getRepoVisibility(t *testing.T) {
 	// test request fail for invalid authorization header
 	headerMap["Authorization"] = ""
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -120,15 +120,15 @@ func Test_getRepoVisibility(t *testing.T) {
 	// test request fail for non existing user w/o authorization
 	headerMap["Authorization"] = "Bearer "
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for existing user, non existing repository w/o authorization
-	headerMap["Authorization"] = "Bearer "
+	// test request fail for non existing user, with authorization
+	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -136,7 +136,7 @@ func Test_getRepoVisibility(t *testing.T) {
 	// test request fail for existing user, non existing repository with authorization
 	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -204,7 +204,7 @@ func Test_setRepoVisibility(t *testing.T) {
 
 	// test request fail for missing authorization header
 	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, nil, http.StatusForbidden)
+	_, err = RunRequest(method, url, nil, nil, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -212,7 +212,7 @@ func Test_setRepoVisibility(t *testing.T) {
 	// test request fail for invalid authorization header
 	headerMap["Authorization"] = ""
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -220,28 +220,28 @@ func Test_setRepoVisibility(t *testing.T) {
 	// test request fail for non existing user w/o authorization
 	headerMap["Authorization"] = "Bearer "
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
-	if err != nil {
-		t.Fatalf("%v\n", err)
-	}
-
-	// test request fail for existing user, non existing repository w/o authorization
-	headerMap["Authorization"] = "Bearer "
-	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
-	if err != nil {
-		t.Fatalf("%v\n", err)
-	}
-
-	// test request fail for existing user, existing repository w/o authorization
-	headerMap["Authorization"] = "Bearer "
-	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
 	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for existing user, existing repository with authorization and missing body
+	// test request fail for non existing user, with authorization
+	headerMap["Authorization"] = "Bearer " + token
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	// test request fail for existing user, non existing repository, with authorization
+	headerMap["Authorization"] = "Bearer " + token
+	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	// test request fail for existing user, existing repository, with authorization, missing body
 	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
 	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
@@ -344,7 +344,7 @@ func Test_patchRepoSettings(t *testing.T) {
 
 	// test request fail for missing authorization header
 	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, nil, http.StatusForbidden)
+	_, err = RunRequest(method, url, nil, nil, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -352,36 +352,36 @@ func Test_patchRepoSettings(t *testing.T) {
 	// test request fail for missing bearer token in authorization header
 	headerMap["Authorization"] = ""
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	// test request fail for non existing user with invalid authorization.
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
 	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for non existing user.
-	headerMap["Authorization"] = "Bearer "
+	// test request fail for non existing user, with authorization.
+	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for existing user, non existing repository w/o proper authorization.
-	headerMap["Authorization"] = "Bearer "
-	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
-	if err != nil {
-		t.Fatalf("%v\n", err)
-	}
-
-	// test request fail for existing user, non existing repository with proper authorization.
+	// test request fail for existing user, non existing repository, with authorization.
 	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for existing user, existing repository with authorization and missing body.
+	// test request fail for existing user, existing repository, with authorization, missing body.
 	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, validUser, validRepo)
 	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -197,12 +197,36 @@ func Test_setRepoVisibility(t *testing.T) {
 		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
 	}
 
-	// test request fail for non existing user
+	// test request fail for missing authorization header
 	url := fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
 	req, err := http.NewRequest("PUT", url, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = makeRequest(t, req, http.StatusForbidden)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test request fail for invalid authorization header
+	url = fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
+	req, err = http.NewRequest("PUT", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Authorization", "")
+	_, err = makeRequest(t, req, http.StatusForbidden)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test request fail for non existing user w/o authorization
+	url = fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
+	req, err = http.NewRequest("PUT", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Authorization", "Bearer ")
 	_, err = makeRequest(t, req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
@@ -214,18 +238,7 @@ func Test_setRepoVisibility(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = makeRequest(t, req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// test request fail for existing user, non existing repository with authorization
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, invalidRepo)
-	req, err = http.NewRequest("PUT", url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", "Bearer ")
 	_, err = makeRequest(t, req, http.StatusBadRequest)
 	if err != nil {
 		t.Fatal(err)
@@ -237,6 +250,7 @@ func Test_setRepoVisibility(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("Authorization", "Bearer ")
 	_, err = makeRequest(t, req, http.StatusForbidden)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -86,82 +86,65 @@ func Test_varsToRepoID(t *testing.T) {
 }
 
 func Test_getRepoVisibility(t *testing.T) {
+	const method = "GET"
+	const urlTemplate = "/users/%s/repos/%s/visibility"
+
 	const invalidUser = "iDoNotExist"
 	const invalidRepo = "iDoNotExist"
 	const validUser = "alice"
 	const validPublicRepo = "auth"
 	const validPrivateRepo = "exrepo"
 
-	// test request fail for missing authorization header
-	url := fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
-	req, err := http.NewRequest("GET", url, nil)
+	headerMap := make(map[string]string)
+
+	token, err := server.users.TokenForUser(validUser)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Could not make token for %q: %v, %v", validUser, token, err)
 	}
-	_, err = makeRequest(req, http.StatusForbidden)
+
+	// test request fail for missing authorization header
+	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, nil, http.StatusForbidden)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for invalid authorization header
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
-	req, err = http.NewRequest("GET", url, nil)
+	headerMap["Authorization"] = ""
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "")
-	_, err = makeRequest(req, http.StatusForbidden)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for non existing user w/o authorization
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
-	req, err = http.NewRequest("GET", url, nil)
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, non existing repository w/o authorization
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, invalidRepo)
-	req, err = http.NewRequest("GET", url, nil)
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, non existing repository with authorization
-	token, err := server.users.TokenForUser(validUser)
+	headerMap["Authorization"] = "Bearer " + token
+	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request for existing user, existing public repository with authorization
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, validPublicRepo)
-	req, err = http.NewRequest("GET", url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	token, err = server.users.TokenForUser(validUser)
-	if err != nil {
-		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	resp, err := makeRequest(req, http.StatusOK)
+	headerMap["Authorization"] = "Bearer " + token
+	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
+	resp, err := RunRequest(method, url, nil, headerMap, http.StatusOK)
 	if err != nil {
 		t.Fatalf("Unexpected error on public repository: %v\n", err)
 	}
@@ -180,17 +163,9 @@ func Test_getRepoVisibility(t *testing.T) {
 	}
 
 	// test request for existing user, existing private repository with authorization
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, validPrivateRepo)
-	req, err = http.NewRequest("GET", url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	token, err = server.users.TokenForUser(validUser)
-	if err != nil {
-		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	resp, err = makeRequest(req, http.StatusOK)
+	headerMap["Authorization"] = "Bearer " + token
+	url = fmt.Sprintf(urlTemplate, validUser, validPrivateRepo)
+	resp, err = RunRequest(method, url, nil, headerMap, http.StatusOK)
 	if err != nil {
 		t.Fatalf("Unexpected error on public repository: %v\n", err)
 	}
@@ -206,10 +181,20 @@ func Test_getRepoVisibility(t *testing.T) {
 }
 
 func Test_setRepoVisibility(t *testing.T) {
+	const method = "PUT"
+	const urlTemplate = "/users/%s/repos/%s/visibility"
+
 	const invalidUser = "iDoNotExist"
 	const invalidRepo = "iDoNotExist"
 	const validUser = "alice"
 	const validPublicRepo = "auth"
+
+	headerMap := make(map[string]string)
+
+	token, err := server.users.TokenForUser(validUser)
+	if err != nil {
+		t.Fatalf("Could not make token for %q: %v, %v", validUser, token, err)
+	}
 
 	// Currently the test repositories are set up only once.
 	// This means tests changing repository settings are not independent,
@@ -217,122 +202,81 @@ func Test_setRepoVisibility(t *testing.T) {
 	// TODO organize the repo setup for tests so that they are reset for every test.
 	defer server.repos.SetRepoVisibility(store.RepoId{Owner: validUser, Name: validPublicRepo}, true)
 
-	token, err := server.users.TokenForUser(validUser)
-	if err != nil {
-		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
-	}
-
 	// test request fail for missing authorization header
-	url := fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
-	req, err := http.NewRequest("PUT", url, nil)
+	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, nil, http.StatusForbidden)
 	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = makeRequest(req, http.StatusForbidden)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for invalid authorization header
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
-	req, err = http.NewRequest("PUT", url, nil)
+	headerMap["Authorization"] = ""
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "")
-	_, err = makeRequest(req, http.StatusForbidden)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for non existing user w/o authorization
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", invalidUser, invalidRepo)
-	req, err = http.NewRequest("PUT", url, nil)
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, non existing repository w/o authorization
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, invalidRepo)
-	req, err = http.NewRequest("PUT", url, nil)
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository w/o authorization
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, validPublicRepo)
-	req, err = http.NewRequest("PUT", url, nil)
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(req, http.StatusForbidden)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository with authorization and missing body
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, validPublicRepo)
-	req, err = http.NewRequest("PUT", url, nil)
+	headerMap["Authorization"] = "Bearer " + token
+	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository with authorization and empty body
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, validPublicRepo)
-	req, err = http.NewRequest("PUT", url, strings.NewReader(""))
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
+	_, err = RunRequest(method, url, strings.NewReader(""), headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository with authorization and invalid request body
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, validPublicRepo)
-	req, err = http.NewRequest("PUT", url, strings.NewReader("{}"))
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
+	_, err = RunRequest(method, url, strings.NewReader("{}"), headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository with authorization and invalid request field type
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, validPublicRepo)
-	req, err = http.NewRequest("PUT", url, strings.NewReader(`{"public":"True"}`))
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
+	_, err = RunRequest(method, url, strings.NewReader(`{"public":"True"}`), headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
-	// test correct request, set public from true to false
+	// set up test for valid put request
 	rid := store.RepoId{Owner: validUser, Name: validPublicRepo}
 	err = server.repos.SetRepoVisibility(rid, true)
 	if err != nil {
@@ -346,16 +290,13 @@ func Test_setRepoVisibility(t *testing.T) {
 		t.Fatalf("Invalid repository visibility: %t\n", check)
 	}
 
-	url = fmt.Sprintf("/users/%s/repos/%s/visibility", validUser, validPublicRepo)
-	req, err = http.NewRequest("PUT", url, strings.NewReader(`{"public":false}`))
+	// test correct request, set public from true to false
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validPublicRepo)
+	resp, err := RunRequest(method, url, strings.NewReader(`{"public":false}`), headerMap, http.StatusOK)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	resp, err := makeRequest(req, http.StatusOK)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	var visibility struct {
@@ -377,19 +318,23 @@ func Test_setRepoVisibility(t *testing.T) {
 	if check {
 		t.Fatalf("Invalid repository visibility: %t\n", check)
 	}
-	// reset repository setting
-	err = server.repos.SetRepoVisibility(rid, true)
-	if err != nil {
-		t.Fatal("Unable to set repository visibility.")
-	}
 }
 
 func Test_patchRepoSettings(t *testing.T) {
-	const settingsUrl = "/users/%s/repos/%s/settings"
+	const method = "PATCH"
+	const urlTemplate = "/users/%s/repos/%s/settings"
+
 	const invalidUser = "iDoNotExist"
 	const invalidRepo = "iDoNotExist"
 	const validUser = "alice"
 	const validRepo = "auth"
+
+	headerMap := make(map[string]string)
+
+	token, err := server.users.TokenForUser(validUser)
+	if err != nil {
+		t.Fatalf("Could not make token for %q: %v, %v", validUser, token, err)
+	}
 
 	// Reset repository setting after the test
 	defer server.repos.SetRepoVisibility(store.RepoId{Owner: validUser, Name: validRepo}, true)
@@ -397,127 +342,87 @@ func Test_patchRepoSettings(t *testing.T) {
 	// TODO the following section is actually just a copy of the first part
 	// TODO of the get/setRepoVisibility tests. Good enough for now, but unify at some point.
 
-	token, err := server.users.TokenForUser(validUser)
-	if err != nil {
-		t.Fatalf("could not make token for %q: %v, %v", validUser, token, err)
-	}
-
 	// test request fail for missing authorization header
-	url := fmt.Sprintf(settingsUrl, invalidUser, invalidRepo)
-	req, err := http.NewRequest("PATCH", url, nil)
+	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, nil, http.StatusForbidden)
 	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = makeRequest(req, http.StatusForbidden)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for missing bearer token in authorization header
-	url = fmt.Sprintf(settingsUrl, invalidUser, invalidRepo)
-	req, err = http.NewRequest("PATCH", url, nil)
+	headerMap["Authorization"] = ""
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "")
-	_, err = makeRequest(req, http.StatusForbidden)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for non existing user.
-	url = fmt.Sprintf(settingsUrl, invalidUser, invalidRepo)
-	req, err = http.NewRequest("PATCH", url, nil)
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, non existing repository w/o proper authorization.
-	url = fmt.Sprintf(settingsUrl, validUser, invalidRepo)
-	req, err = http.NewRequest("PATCH", url, nil)
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer ")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, non existing repository with proper authorization.
-	url = fmt.Sprintf(settingsUrl, validUser, invalidRepo)
-	req, err = http.NewRequest("PATCH", url, nil)
+	headerMap["Authorization"] = "Bearer " + token
+	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository with authorization and missing body.
-	url = fmt.Sprintf(settingsUrl, validUser, validRepo)
-	req, err = http.NewRequest("PATCH", url, nil)
+	headerMap["Authorization"] = "Bearer " + token
+	url = fmt.Sprintf(urlTemplate, validUser, validRepo)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository with authorization and empty body.
-	url = fmt.Sprintf(settingsUrl, validUser, validRepo)
-	req, err = http.NewRequest("PATCH", url, strings.NewReader(""))
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validRepo)
+	_, err = RunRequest(method, url, strings.NewReader(""), headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository with authorization and missing patchable field.
-	url = fmt.Sprintf(settingsUrl, validUser, validRepo)
-	req, err = http.NewRequest("PATCH", url, strings.NewReader(`{"otherfield":"has nowhere to patch"}`))
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validRepo)
+	body := `{"otherfield":"has nowhere to patch"}`
+	_, err = RunRequest(method, url, strings.NewReader(body), headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for existing user, existing repository with authorization and invalid patchable field value.
-	url = fmt.Sprintf(settingsUrl, validUser, validRepo)
-	req, err = http.NewRequest("PATCH", url, strings.NewReader(`{"public": "string"}`))
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validRepo)
+	body = `{"public": "string"}`
+	_, err = RunRequest(method, url, strings.NewReader(body), headerMap, http.StatusBadRequest)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusBadRequest)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	// set up for valid PATCH tests
 	const repoStartDesc = "description"
 	const repoStartVisibility = false
 	repoId := store.RepoId{Owner: validUser, Name: validRepo}
-	repo, err := git.OpenRepository(server.repos.IdToPath(repoId))
-
+	repo, _ := git.OpenRepository(server.repos.IdToPath(repoId))
 	err = repo.WriteDescription(repoStartDesc)
 	if err != nil {
 		t.Fatalf("Error setting up repository description for test: %v\n", err)
@@ -530,16 +435,14 @@ func Test_patchRepoSettings(t *testing.T) {
 
 	// test request patch for existing user, existing repository with authorization and "public" only.
 	const newPublic = true
-	url = fmt.Sprintf(settingsUrl, validUser, validRepo)
-	req, err = http.NewRequest("PATCH", url, strings.NewReader(fmt.Sprintf(`{"public": %t}`, newPublic)))
+
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validRepo)
+	body = fmt.Sprintf(`{"public": %t}`, newPublic)
+	_, err = RunRequest(method, url, strings.NewReader(body), headerMap, http.StatusOK)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusOK)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	newRepoDesc := repo.ReadDescription()
@@ -555,16 +458,13 @@ func Test_patchRepoSettings(t *testing.T) {
 	oldRepoVis, _ := server.repos.GetRepoVisibility(repoId)
 	const newDesc = "a new description"
 
-	url = fmt.Sprintf(settingsUrl, validUser, validRepo)
-	req, err = http.NewRequest("PATCH", url, strings.NewReader(fmt.Sprintf(`{"description": %q}`, newDesc)))
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validRepo)
+	body = fmt.Sprintf(`{"description": %q}`, newDesc)
+	_, err = RunRequest(method, url, strings.NewReader(body), headerMap, http.StatusOK)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusOK)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	newRepoDesc = repo.ReadDescription()
@@ -579,18 +479,14 @@ func Test_patchRepoSettings(t *testing.T) {
 	// test request patch for existing user, existing repository with authorization and both "description" and "public".
 	const anotherPublic = false
 	const anotherDesc = "another new description"
-	body := fmt.Sprintf(`{"description": %q, "public": %t}`, anotherDesc, anotherPublic)
 
-	url = fmt.Sprintf(settingsUrl, validUser, validRepo)
-	req, err = http.NewRequest("PATCH", url, strings.NewReader(body))
+	headerMap["Authorization"] = "Bearer " + token
+	headerMap["Content-Type"] = "application/json"
+	url = fmt.Sprintf(urlTemplate, validUser, validRepo)
+	body = fmt.Sprintf(`{"description": %q, "public": %t}`, anotherDesc, anotherPublic)
+	_, err = RunRequest(method, url, strings.NewReader(body), headerMap, http.StatusOK)
 	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	_, err = makeRequest(req, http.StatusOK)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%v\n", err)
 	}
 
 	newRepoDesc = repo.ReadDescription()

--- a/cmd/gin-repod/routes.go
+++ b/cmd/gin-repod/routes.go
@@ -14,6 +14,8 @@ func (s *Server) SetupRoutes() {
 	r.HandleFunc("/users/{user}/repos", s.createRepo).Methods("POST")
 	r.HandleFunc("/users/{user}/repos", s.listRepos).Methods("GET")
 
+	r.HandleFunc("/users/{user}/repos/{repo}/settings", s.patchRepoSettings).Methods("PATCH")
+
 	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.getRepoVisibility).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.setRepoVisibility).Methods("PUT")
 

--- a/store/repo.go
+++ b/store/repo.go
@@ -108,13 +108,16 @@ func (store *RepoStore) gitPath() string {
 	return filepath.Join(store.Path, "git")
 }
 
-func (store *RepoStore) idToPath(id RepoId) string {
+// IdToPath returns the complete path to the root folder of
+// the repository referenced by the RepoId. Method does not
+// check whether the repository actually exists.
+func (store *RepoStore) IdToPath(id RepoId) string {
 	return filepath.Join(store.gitPath(), id.Owner, id.Name+".git")
 }
 
 // RepoExists returns true if the path to a provided RepoId exists, false otherwise.
 func (store *RepoStore) RepoExists(id RepoId) (bool, error) {
-	repoPath := store.idToPath(id)
+	repoPath := store.IdToPath(id)
 	_, err := os.Stat(repoPath)
 
 	if err != nil && os.IsNotExist(err) {
@@ -127,7 +130,7 @@ func (store *RepoStore) RepoExists(id RepoId) (bool, error) {
 }
 
 func (store *RepoStore) CreateRepo(id RepoId) (*git.Repository, error) {
-	path := store.idToPath(id)
+	path := store.IdToPath(id)
 
 	_, err := os.Stat(path)
 
@@ -271,12 +274,12 @@ func (store *RepoStore) ListPublicRepos() ([]RepoId, error) {
 }
 
 func (store *RepoStore) OpenGitRepo(id RepoId) (*git.Repository, error) {
-	path := store.idToPath(id)
+	path := store.IdToPath(id)
 	return git.OpenRepository(path)
 }
 
 func (store *RepoStore) GetRepoVisibility(id RepoId) (bool, error) {
-	base := store.idToPath(id)
+	base := store.IdToPath(id)
 	path := filepath.Join(base, "gin", "public")
 
 	_, err := os.Stat(path)
@@ -302,7 +305,7 @@ func (store *RepoStore) SetRepoVisibility(id RepoId, public bool) error {
 		return nil
 	}
 
-	path := filepath.Join(store.idToPath(id), "gin", "public")
+	path := filepath.Join(store.IdToPath(id), "gin", "public")
 	if public {
 		_, err := os.Create(path)
 		if err != nil {
@@ -320,7 +323,7 @@ func (store *RepoStore) SetAccessLevel(id RepoId, user string, level AccessLevel
 	}
 
 	//TODO: check user name
-	path := filepath.Join(store.idToPath(id), "gin", "sharing", user)
+	path := filepath.Join(store.IdToPath(id), "gin", "sharing", user)
 
 	if level == NoAccess {
 		err := os.Remove(path)
@@ -340,7 +343,7 @@ func (store *RepoStore) readAccessLevel(id RepoId, user string) (AccessLevel, er
 		return NoAccess, nil
 	}
 
-	path := filepath.Join(store.idToPath(id), "gin", "sharing", user)
+	path := filepath.Join(store.IdToPath(id), "gin", "sharing", user)
 
 	data, err := ioutil.ReadFile(path)
 	if os.IsNotExist(err) {
@@ -386,7 +389,7 @@ func (store *RepoStore) GetAccessLevel(id RepoId, user string) (AccessLevel, err
 }
 
 func (store *RepoStore) ListSharedAccess(id RepoId) (map[string]AccessLevel, error) {
-	path := filepath.Join(store.idToPath(id), "gin", "sharing")
+	path := filepath.Join(store.IdToPath(id), "gin", "sharing")
 
 	dir, err := os.Open(path)
 

--- a/store/repo_test.go
+++ b/store/repo_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/G-Node/gin-repo/internal/testbed"
+	"strings"
+	"path/filepath"
 )
 
 var users UserStore
@@ -160,5 +162,17 @@ func Test_RepoExists(t *testing.T) {
 	}
 	if !exists {
 		t.Fatal("Did not expect false on valid RepoId.")
+	}
+}
+
+func TestRepoStore_IdToPath(t *testing.T) {
+	const repoOwner = "alice"
+	const repoName = "auth"
+
+	r := RepoId{ Owner: repoOwner, Name: repoName }
+	path := repos.IdToPath(r)
+
+	if !strings.Contains(path, fmt.Sprintf(filepath.Join("repos", "git", repoOwner, repoName + ".git"))) {
+		t.Fatalf("Received unexpected repository path: %q\n", path)
 	}
 }

--- a/store/repo_test.go
+++ b/store/repo_test.go
@@ -3,12 +3,12 @@ package store
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/G-Node/gin-repo/internal/testbed"
-	"path/filepath"
-	"strings"
 )
 
 var users UserStore

--- a/store/repo_test.go
+++ b/store/repo_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/G-Node/gin-repo/internal/testbed"
-	"strings"
 	"path/filepath"
+	"strings"
 )
 
 var users UserStore
@@ -169,10 +169,10 @@ func TestRepoStore_IdToPath(t *testing.T) {
 	const repoOwner = "alice"
 	const repoName = "auth"
 
-	r := RepoId{ Owner: repoOwner, Name: repoName }
+	r := RepoId{Owner: repoOwner, Name: repoName}
 	path := repos.IdToPath(r)
 
-	if !strings.Contains(path, fmt.Sprintf(filepath.Join("repos", "git", repoOwner, repoName + ".git"))) {
+	if !strings.Contains(path, fmt.Sprintf(filepath.Join("repos", "git", repoOwner, repoName+".git"))) {
 		t.Fatalf("Received unexpected repository path: %q\n", path)
 	}
 }


### PR DESCRIPTION
- Uses PATCH to change repository settings, this closes issue #43.
- refactors [cmd/repod] test function `makeRequest`.
- refactors private [store] function `IdToPath` to public and adds test.
- adds [cmd/repod] test function `RunRequest`.