### PR TITLE
REST endpoints to handle repository collaborators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ contrib/**/exrepo
 scratchpad.go
 
 **/gin.secret
+
+# test coverage files
+*.cov

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -837,3 +837,7 @@ func (s *Server) putRepoCollaborator(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 }
+
+func (s *Server) deleteRepoCollaborator(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -753,3 +753,87 @@ func (s *Server) listRepoCollaborators(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(respBody)
 }
+
+// putRepoCollaborator adds a user with the submitted access level to the sharing folder
+// of a repository. If the user already exists, an http.StatusConflict is returned.
+func (s *Server) putRepoCollaborator(w http.ResponseWriter, r *http.Request) {
+	header := r.Header.Get("Authorization")
+	if header == "" || !strings.HasPrefix(header, "Bearer ") {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	ivars := mux.Vars(r)
+	rid, err := s.varsToRepoID(ivars)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	exists, err := s.repos.RepoExists(rid)
+	if err != nil || !exists {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	_, ok := s.checkAccess(w, r, rid, store.AdminAccess)
+	if !ok {
+		return
+	}
+
+	username := ivars["username"]
+	if username == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// TODO check if provided username actually exists in the user store (local and auth).
+
+	if rid.Owner == username {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	repoAccess, err := s.repos.ListSharedAccess(rid)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if _, exists := repoAccess[username]; exists {
+		// TODO return error message along the lines "already exists".
+		w.WriteHeader(http.StatusConflict)
+		return
+	}
+
+	var accessLevel struct{ Permission string }
+
+	if r.Body == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	err = json.Unmarshal(b, &accessLevel)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	level, err := store.ParseAccessLevel(accessLevel.Permission)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = s.repos.SetAccessLevel(rid, username, level)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -512,16 +512,16 @@ func Test_listRepoCollaborators(t *testing.T) {
 	const validRepoEmpty = "auth"
 	const validRepoCollaborator = "openfmri"
 
-	// test request fail for non existing user.
+	// test request fail for invalid user.
 	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
-	_, err := RunRequest(method, url, nil, nil, http.StatusBadRequest)
+	_, err := RunRequest(method, url, nil, nil, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for existing user, non existing repository.
-	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo)
-	_, err = RunRequest(method, url, nil, nil, http.StatusBadRequest)
+	// test request fail for valid user, invalid repository.
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
+	_, err = RunRequest(method, url, nil, nil, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -555,6 +555,8 @@ func Test_listRepoCollaborators(t *testing.T) {
 	if len(collaborators) != 1 {
 		t.Errorf("Expected one collaborator but got: %v\n", collaborators)
 	}
+
+	// TODO add tests for private repository and tests for non owner
 }
 
 func Test_putRepoCollaborator(t *testing.T) {
@@ -582,39 +584,39 @@ func Test_putRepoCollaborator(t *testing.T) {
 
 	// test request fail for missing authorization header.
 	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo, invalidPutUser)
-	_, err = RunRequest(method, url, nil, nil, http.StatusForbidden)
+	_, err = RunRequest(method, url, nil, nil, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for missing bearer token in authorization header.
+	// test request fail for missing bearer token prefix in authorization header.
 	headerMap["Authorization"] = ""
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo, invalidPutUser)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	// test request fail for missing bearer token.
+	headerMap["Authorization"] = "Bearer "
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo, validPutUser)
 	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for non existing user.
-	headerMap["Authorization"] = "Bearer "
+	// test request fail for non existing user, with authorization.
+	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo, validPutUser)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for existing user, non existing repository.
-	headerMap["Authorization"] = "Bearer "
+	// test request fail for existing user, non existing repository, with authorization.
+	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo, validPutUser)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
-	if err != nil {
-		t.Fatalf("%v\n", err)
-	}
-
-	// test request fail for existing user, existing repository w/o proper authorization.
-	headerMap["Authorization"] = "Bearer "
-	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo, validPutUser)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -733,39 +735,39 @@ func Test_deleteRepoCollaborator(t *testing.T) {
 
 	// test request fail for missing authorization header.
 	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo, invalidDeleteUser)
-	_, err = RunRequest(method, url, nil, nil, http.StatusForbidden)
+	_, err = RunRequest(method, url, nil, nil, http.StatusNotFound)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	// test request fail for missing bearer token header in authorization header.
+	headerMap["Authorization"] = ""
+	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo, invalidDeleteUser)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
 	// test request fail for missing bearer token in authorization header.
-	headerMap["Authorization"] = ""
+	headerMap["Authorization"] = "Bearer "
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo, invalidDeleteUser)
 	_, err = RunRequest(method, url, nil, headerMap, http.StatusForbidden)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for non existing user.
-	headerMap["Authorization"] = "Bearer "
+	// test request fail for non existing user, with authorization.
+	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, invalidUser, invalidRepo, invalidDeleteUser)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	// test request fail for existing user, non existing repository.
-	headerMap["Authorization"] = "Bearer "
+	// test request fail for existing user, non existing repository, with authorization.
+	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo, invalidDeleteUser)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
-	if err != nil {
-		t.Fatalf("%v\n", err)
-	}
-
-	// test request fail for existing user, existing repository w/o proper authorization.
-	headerMap["Authorization"] = "Bearer "
-	url = fmt.Sprintf(urlTemplate, validUser, invalidRepo, invalidDeleteUser)
-	_, err = RunRequest(method, url, nil, headerMap, http.StatusBadRequest)
+	_, err = RunRequest(method, url, nil, headerMap, http.StatusNotFound)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/cmd/gin-repod/routes.go
+++ b/cmd/gin-repod/routes.go
@@ -19,6 +19,8 @@ func (s *Server) SetupRoutes() {
 	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.getRepoVisibility).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.setRepoVisibility).Methods("PUT")
 
+	r.HandleFunc("/users/{user}/repos/{repo}/collaborators", s.listRepoCollaborators).Methods("GET")
+
 	r.HandleFunc("/users/{user}/repos/{repo}/branches/{branch}", s.getBranch).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/objects/{object}", s.getObject).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/browse/{branch}", s.browseRepo).Methods("GET")

--- a/cmd/gin-repod/routes.go
+++ b/cmd/gin-repod/routes.go
@@ -21,6 +21,7 @@ func (s *Server) SetupRoutes() {
 
 	r.HandleFunc("/users/{user}/repos/{repo}/collaborators", s.listRepoCollaborators).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/collaborators/{username}", s.putRepoCollaborator).Methods("PUT")
+	r.HandleFunc("/users/{user}/repos/{repo}/collaborators/{username}", s.deleteRepoCollaborator).Methods("DELETE")
 
 	r.HandleFunc("/users/{user}/repos/{repo}/branches/{branch}", s.getBranch).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/objects/{object}", s.getObject).Methods("GET")

--- a/cmd/gin-repod/routes.go
+++ b/cmd/gin-repod/routes.go
@@ -20,6 +20,7 @@ func (s *Server) SetupRoutes() {
 	r.HandleFunc("/users/{user}/repos/{repo}/visibility", s.setRepoVisibility).Methods("PUT")
 
 	r.HandleFunc("/users/{user}/repos/{repo}/collaborators", s.listRepoCollaborators).Methods("GET")
+	r.HandleFunc("/users/{user}/repos/{repo}/collaborators/{username}", s.putRepoCollaborator).Methods("PUT")
 
 	r.HandleFunc("/users/{user}/repos/{repo}/branches/{branch}", s.getBranch).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/objects/{object}", s.getObject).Methods("GET")

--- a/contrib/mkdata.py
+++ b/contrib/mkdata.py
@@ -81,10 +81,11 @@ def create_repo(user, repo):
     if repo.get("public", False):
         target = os.path.join(gindir, "public")
         open(target, "w")
+    # always create sharing folder even if empty
+    sharing = os.path.join(gindir, "sharing")
+    os.mkdir(sharing)
     shared = repo.get("shared") or {}
     for buddy, level in shared.items():
-        sharing = os.path.join(gindir, "sharing")
-        os.mkdir(sharing)
         target = os.path.join(sharing, buddy)
         with open(target, "w") as fd:
             fd.write(level)

--- a/git/repo.go
+++ b/git/repo.go
@@ -98,6 +98,13 @@ func (repo *Repository) WriteDescription(description string) error {
 	return ioutil.WriteFile(path, []byte(description), 0666)
 }
 
+// DeleteCollaborator removes a collaborator file from the repositories sharing folder.
+func (repo *Repository) DeleteCollaborator(username string) error {
+	filePath := filepath.Join(repo.Path, "gin", "sharing", username)
+
+	return os.Remove(filePath)
+}
+
 //OpenObject returns the git object for a give id (SHA1).
 func (repo *Repository) OpenObject(id SHA1) (Object, error) {
 	obj, err := repo.openRawObject(id)

--- a/store/repo.go
+++ b/store/repo.go
@@ -148,6 +148,9 @@ func (store *RepoStore) CreateRepo(id RepoId) (*git.Repository, error) {
 	gin := filepath.Join(path, "gin")
 	os.Mkdir(gin, 0775) //TODO: what to do about errors?
 
+	sharing := filepath.Join(gin, "sharing")
+	os.Mkdir(sharing, 0775)
+
 	return repo, nil
 }
 


### PR DESCRIPTION
- close #42.
- adds `DeleteCollaborator` method to [git/repo].
- changes store/repo `CreateRepo`to always create the `[repoPath]/gin/sharing` folder.
- updates the [contrib/mkdata.py] script to always create the `[repoPath]/gin/sharing` folder.
- updates gitignore to ignore profile coverage files.
