### PR TITLE
Fixes, cleanups and improvements

### DIFF
--- a/cmd/gin-repod/main.go
+++ b/cmd/gin-repod/main.go
@@ -182,6 +182,10 @@ func (s *Server) SetupStores() {
 	}
 
 	repos, err := s.repos.ListRepos()
+	if err != nil {
+		s.log(PANIC, "Could not read repo store: %v", err)
+		os.Exit(13)
+	}
 
 	s.log(DEBUG, "repos detected:")
 	for _, repo := range repos {
@@ -196,7 +200,7 @@ func (s *Server) SetupStores() {
 		access, err := s.repos.ListSharedAccess(repo)
 
 		if err != nil {
-
+			s.log(WARN, " - shared access error: %v", err)
 		} else if len(access) > 0 {
 			s.log(DEBUG, " - sharing:")
 			for k, v := range access {

--- a/cmd/gin-repod/main_test.go
+++ b/cmd/gin-repod/main_test.go
@@ -89,7 +89,7 @@ func RunRequest(method string, url string, body io.Reader,
 		return nil, err
 	}
 
-	if header != nil && len(header) > 0 {
+	if len(header) > 0 {
 		for k, v := range header {
 			req.Header.Add(k, v)
 		}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -297,7 +297,7 @@ func (s *Server) varsToRepoID(vars map[string]string) (store.RepoId, error) {
 	iuser := vars["user"]
 	irepo := vars["repo"]
 
-	repoId := store.RepoId{iuser, irepo}
+	repoId := store.RepoId{Owner: iuser, Name: irepo}
 	if iuser == "" || irepo == "" {
 		return repoId, errors.New("Missing arguments.")
 	}

--- a/coverage.sh
+++ b/coverage.sh
@@ -13,4 +13,4 @@ do
     fi
   fi
 done
-
+rm tmp.out;

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,6 +10,8 @@ CWRN="\033[33;01m"
 
 GOPATH=/opt/deploy/go
 
+sudo -v -p "Certain commands require sudo access. Please enter your password: "
+
 echo -e "Running in ${CAOK}$PWD $CNOC"
 REPO=$(basename $PWD)
 if [ "$REPO" != "gin-repo" ]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,7 @@ GOPATH=/opt/deploy/go
 echo -e "Running in ${CAOK}$PWD $CNOC"
 REPO=$(basename $PWD)
 if [ "$REPO" != "gin-repo" ]; then
-    echo -e "${CERR}* Not in gin-repo *{CNOC}"
+    echo -e "${CERR}* Not in gin-repo *${CNOC}"
     exit 1
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# run this script as normal user w/o sudo from within the gin-repo root folder.
 set -e
 
 CNOC="\033[0m"

--- a/store/repo.go
+++ b/store/repo.go
@@ -206,7 +206,7 @@ func (store *RepoStore) ListReposForUser(uid string) ([]RepoId, error) {
 		return nil, fmt.Errorf("%q is not a directory as expected", userpath)
 	}
 
-	names, err := filepath.Glob(filepath.Join(userpath, "*.git"))
+	names, _ := filepath.Glob(filepath.Join(userpath, "*.git"))
 
 	var repos []RepoId
 	for _, path := range names {


### PR DESCRIPTION
- [deploy.sh] adds comment on how to run deploy.sh.
- [coverage.sh] adds cleanup of the temporary file when creating the coverage file.
- [cmd/repod] `main`: when setting up the store on startup, exit on ListRepos error and log any SharedAccess error.
- [store/repo] ignore `filepath.Glob` since it returns only one error: the malformed pattern error.
- [cmd/repod] in `varsToRepoID`, use fieldnames when assigning values to the respective fields.
- [cmd/repod] `main_test`: remove redundant nil check from `RunRequest`.