### PR TITLE
Collaborator handling

### DIFF
--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -827,7 +827,13 @@ func (s *Server) putRepoCollaborator(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// jquery 1.9+ ajax calls require a proper JSON response body, otherwise they will default to error.
+	returnBody, _ := json.Marshal(struct {
+		Response string `json:"Response"`
+	}{"Success"})
+
 	w.WriteHeader(http.StatusOK)
+	w.Write(returnBody)
 }
 
 // deleteRepoCollaborator removes a user from the sharing folder of a repository.

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -769,7 +769,7 @@ func (s *Server) listRepoCollaborators(w http.ResponseWriter, r *http.Request) {
 }
 
 // putRepoCollaborator adds a user with the submitted access level to the sharing folder
-// of a repository. If the user already exists, an http.StatusConflict is returned.
+// of a repository. If the user already exists, the access level of this user is updated.
 func (s *Server) putRepoCollaborator(w http.ResponseWriter, r *http.Request) {
 	ivars := mux.Vars(r)
 	rid, err := s.varsToRepoID(ivars)
@@ -793,18 +793,6 @@ func (s *Server) putRepoCollaborator(w http.ResponseWriter, r *http.Request) {
 
 	if rid.Owner == username {
 		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	repoAccess, err := s.repos.ListSharedAccess(rid)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	if _, exists := repoAccess[username]; exists {
-		// TODO return error message along the lines "already exists".
-		w.WriteHeader(http.StatusConflict)
 		return
 	}
 

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -749,19 +749,21 @@ func (s *Server) listRepoCollaborators(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	type collaborator struct {
+		User        string `json:"User"`
+		AccessLevel string `json:"AccessLevel"`
+	}
+
 	respBody := []byte("[]")
 	if len(repoAccess) > 0 {
-		users := make([]string, len(repoAccess))
+		repoCollaborators := make([]collaborator, len(repoAccess))
 		i := 0
-		for k := range repoAccess {
-			users[i] = k
+		for v := range repoAccess {
+			repoCollaborators[i].User = v
+			repoCollaborators[i].AccessLevel = repoAccess[v].String()
 			i++
 		}
-		respBody, err = json.Marshal(users)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+		respBody, err = json.Marshal(repoCollaborators)
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -750,8 +750,8 @@ func (s *Server) listRepoCollaborators(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type collaborator struct {
-		User        string `json:"User"`
-		AccessLevel string `json:"AccessLevel"`
+		User        string
+		AccessLevel store.AccessLevel
 	}
 
 	respBody := []byte("[]")
@@ -760,7 +760,7 @@ func (s *Server) listRepoCollaborators(w http.ResponseWriter, r *http.Request) {
 		i := 0
 		for v := range repoAccess {
 			repoCollaborators[i].User = v
-			repoCollaborators[i].AccessLevel = repoAccess[v].String()
+			repoCollaborators[i].AccessLevel = repoAccess[v]
 			i++
 		}
 		respBody, err = json.Marshal(repoCollaborators)
@@ -827,13 +827,9 @@ func (s *Server) putRepoCollaborator(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// jquery 1.9+ ajax calls require a proper JSON response body, otherwise they will default to error.
-	returnBody, _ := json.Marshal(struct {
-		Response string `json:"Response"`
-	}{"Success"})
-
 	w.WriteHeader(http.StatusOK)
-	w.Write(returnBody)
+	// jquery 1.9+ ajax calls require a proper JSON response body, otherwise they will default to error.
+	io.WriteString(w, `{"Response": "Success"}`)
 }
 
 // deleteRepoCollaborator removes a user from the sharing folder of a repository.

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -764,6 +764,10 @@ func (s *Server) listRepoCollaborators(w http.ResponseWriter, r *http.Request) {
 			i++
 		}
 		respBody, err = json.Marshal(repoCollaborators)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -504,6 +504,11 @@ func Test_patchRepoSettings(t *testing.T) {
 }
 
 func Test_listRepoCollaborators(t *testing.T) {
+	type collaborator struct {
+		User        string `json:"User"`
+		AccessLevel string `json:"AccessLevel"`
+	}
+
 	const method = "GET"
 	const urlTemplate = "/users/%s/repos/%s/collaborators"
 
@@ -527,20 +532,20 @@ func Test_listRepoCollaborators(t *testing.T) {
 		t.Fatalf("%v\n", err)
 	}
 
-	var collaborators []string
-
 	// test existing user, existing repository, repository w/o collaborators.
+	var repoCollaborators []collaborator
+
 	url = fmt.Sprintf(urlTemplate, validUser, validRepoEmpty)
 	resp, err := RunRequest(method, url, nil, nil, http.StatusOK)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
-	err = json.Unmarshal(resp.Body.Bytes(), &collaborators)
+	err = json.Unmarshal(resp.Body.Bytes(), &repoCollaborators)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(collaborators) != 0 {
-		t.Errorf("Expected empty list but got: %v\n", collaborators)
+	if len(repoCollaborators) != 0 {
+		t.Errorf("Expected empty list but got: %v\n", repoCollaborators)
 	}
 
 	// test existing user, existing repository, repository with collaborators.
@@ -549,12 +554,12 @@ func Test_listRepoCollaborators(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
-	err = json.Unmarshal(resp.Body.Bytes(), &collaborators)
+	err = json.Unmarshal(resp.Body.Bytes(), &repoCollaborators)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(collaborators) != 1 {
-		t.Errorf("Expected one collaborator but got: %v\n", collaborators)
+	if len(repoCollaborators) != 1 {
+		t.Errorf("Expected one collaborator but got: %v\n", repoCollaborators)
 	}
 
 	// TODO add tests for private repository and tests for non owner

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -505,8 +505,8 @@ func Test_patchRepoSettings(t *testing.T) {
 
 func Test_listRepoCollaborators(t *testing.T) {
 	type collaborator struct {
-		User        string `json:"User"`
-		AccessLevel string `json:"AccessLevel"`
+		User        string            `json:"User"`
+		AccessLevel store.AccessLevel `json:"AccessLevel"`
 	}
 
 	const method = "GET"
@@ -517,6 +517,8 @@ func Test_listRepoCollaborators(t *testing.T) {
 	const validUser = "alice"
 	const validRepoEmpty = "auth"
 	const validRepoCollaborator = "openfmri"
+	const validRepoCollaboratorUser = "bob"
+	const validRepoCollaboratorLevel = "is-admin"
 
 	// test request fail for invalid user.
 	url := fmt.Sprintf(urlTemplate, invalidUser, invalidRepo)
@@ -560,6 +562,13 @@ func Test_listRepoCollaborators(t *testing.T) {
 	}
 	if len(repoCollaborators) != 1 {
 		t.Errorf("Expected one collaborator but got: %v\n", repoCollaborators)
+	}
+	if repoCollaborators[0].User != validRepoCollaboratorUser {
+		t.Errorf("Expected user %q but got %q\n", validRepoCollaboratorUser, repoCollaborators[0].User)
+	}
+	if repoCollaborators[0].AccessLevel.String() != validRepoCollaboratorLevel {
+		t.Errorf("Expected access level %q but got %q\n",
+			validRepoCollaboratorLevel, repoCollaborators[0].AccessLevel.String())
 	}
 
 	// TODO add tests for private repository and tests for non owner

--- a/store/repo.go
+++ b/store/repo.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -79,6 +80,22 @@ func (level AccessLevel) String() string {
 	}
 
 	return "no-access"
+}
+
+// MarshalJSON implements Marshaler for AccessLevel.
+func (l *AccessLevel) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.String())
+}
+
+// UnmarshalJSON implements Unmarshaler for AccessLevel.
+func (l *AccessLevel) UnmarshalJSON(bytes []byte) error {
+	var data string
+	err := json.Unmarshal(bytes, &data)
+	if err != nil {
+		return err
+	}
+	*l, err = ParseAccessLevel(data)
+	return err
 }
 
 func ParseAccessLevel(str string) (AccessLevel, error) {


### PR DESCRIPTION
Closes #69.

Additional changes
- A jQuery 1.9+ ajax request requires a non empty JSON string in the request response ([details](http://jquery.com/upgrade-guide/1.9/#jquery-ajax-returning-a-json-result-of-an-empty-string)). This pull request adds a minimal JSON response to `putRepoCollaborator` due to this reason.