### PR TITLE
Provide shared repository flag in repository listings

### DIFF
--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -114,6 +114,7 @@ func (s *Server) repoToWire(id store.RepoId, repo *git.Repository) (wire.Repo, e
 		s.log(WARN, "could not get repo visibility: %v", err)
 		public = false
 	}
+	shared := s.repos.RepoShared(id)
 
 	wr := wire.Repo{
 		Name:        id.Name,
@@ -121,6 +122,7 @@ func (s *Server) repoToWire(id store.RepoId, repo *git.Repository) (wire.Repo, e
 		Description: repo.ReadDescription(),
 		Head:        "master",
 		Public:      public,
+		Shared:      shared,
 	}
 
 	return wr, nil

--- a/store/repo_test.go
+++ b/store/repo_test.go
@@ -176,3 +176,31 @@ func TestRepoStore_IdToPath(t *testing.T) {
 		t.Fatalf("Received unexpected repository path: %q\n", path)
 	}
 }
+
+func TestRepoStore_RepoShared(t *testing.T) {
+	const repoOwner = "alice"
+	const repoInvalid = "iDoNotExist"
+	const repoValid = "repod"
+	const repoShared = "openfmri"
+
+	// Test false on error when opening non existing repository
+	rid := RepoId{Owner: repoOwner, Name: repoInvalid}
+	ok := repos.RepoShared(rid)
+	if ok {
+		t.Fatalf("Expected fail when opening %v\n", rid)
+	}
+
+	// Test false on non shared repository
+	rid.Name = repoValid
+	ok = repos.RepoShared(rid)
+	if ok {
+		t.Fatalf("Expected fail when opening %v\n", rid)
+	}
+
+	// Test true on shared repository
+	rid.Name = repoShared
+	ok = repos.RepoShared(rid)
+	if !ok {
+		t.Fatalf("Expected success when opening %v\n", rid)
+	}
+}

--- a/wire/proto.go
+++ b/wire/proto.go
@@ -16,12 +16,16 @@ type CreateRepo struct {
 	Public      bool
 }
 
+// Repo is used to export basic information about a repository.
+// Public states whether a repository is publicly available.
+// Shared states whether a repository is shared with a collaborator.
 type Repo struct {
 	Name        string
 	Owner       string
 	Description string
-	Public      bool
 	Head        string
+	Public      bool
+	Shared      bool
 }
 
 type Branch struct {


### PR DESCRIPTION
This pull request 
- adds a function to read the shared status of a repository.
- adds a shared repository flag to `wire.Repo` and exports it with every repository list via `wireToRepo`.
- adds test for `store/RepoShared` and updates `repod/repoDescription` test.
