### PR TITLE
GET repoCommits REST endpoint

### DIFF
--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -920,6 +920,10 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 
 	ivars := mux.Vars(r)
 	rid, err := s.varsToRepoID(ivars)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	ibranch := ivars["branch"]
 
@@ -939,8 +943,7 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 		s.log(WARN, "error checking branch %q [%v]", ibranch, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
-	}
-	if !ok {
+	} else if !ok {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -934,6 +934,12 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ok = repo.BranchExists(ibranch)
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
 	res, err := repo.ParseCommitList(ibranch)
 	if err != nil {
 		s.log(ERROR, "%v", err)

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -1006,9 +1006,16 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := repo.ParseCommitList(ibranch)
+	raw, err := repo.CommitsForRef(ibranch)
 	if err != nil {
-		s.log(WARN, "error parsing commitlist [%v]", err)
+		s.log(WARN, "error fetching commits [%v]", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	res, err := commitsToWire(raw, ":=")
+	if err != nil {
+		s.log(WARN, "error wiring commits [%v]", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -944,10 +944,9 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use internal server error for now until we properly deal
-	// with individual errors in ParseCommitList.
-	res, ok := repo.ParseCommitList(ibranch)
-	if !ok {
+	res, err := repo.ParseCommitList(ibranch)
+	if err != nil {
+		s.log(ERROR, "%v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -915,6 +915,7 @@ func (s *Server) repoDescription(w http.ResponseWriter, r *http.Request) {
 }
 
 // listRepoCommits returns a list of all commits from the branch of a specified repository as json.
+// Required access level is PullAccess.
 func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 
 	ivars := mux.Vars(r)
@@ -922,21 +923,10 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 
 	ibranch := ivars["branch"]
 
-	// Do we actually need the check for branch
-	/*
-		if err != nil || ibranch != "master" {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-	*/
-
-	// Don't forget these checks once we have properly implemented the main method
-	/*
-		_, ok := s.checkAccess(w, r, rid, store.PullAccess)
-		if !ok {
-			return
-		}
-	*/
+	_, ok := s.checkAccess(w, r, rid, store.PullAccess)
+	if !ok {
+		return
+	}
 
 	repo, err := s.repos.OpenGitRepo(rid)
 	if err != nil {

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -934,7 +934,12 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ok = repo.BranchExists(ibranch)
+	ok, err = repo.BranchExists(ibranch)
+	if err != nil {
+		s.log(WARN, "error checking branch %q [%v]", ibranch, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -942,7 +947,7 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 
 	res, err := repo.ParseCommitList(ibranch)
 	if err != nil {
-		s.log(ERROR, "%v", err)
+		s.log(WARN, "error parsing commitlist [%v]", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -952,6 +957,6 @@ func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	err = enc.Encode(res)
 	if err != nil {
-		s.log(ERROR, "Oh no, error while encoding after status ok was sent... %v\n", err)
+		s.log(WARN, "error after status ok sent [%v]", err)
 	}
 }

--- a/cmd/gin-repod/repo.go
+++ b/cmd/gin-repod/repo.go
@@ -913,3 +913,12 @@ func (s *Server) repoDescription(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(body)
 }
+
+// listRepoCommits returns a list of all commits from a specified repository as json.
+func (s *Server) listRepoCommits(w http.ResponseWriter, r *http.Request) {
+
+	fmt.Println("Implement me")
+	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, `{"Response": "Implement me"}`)
+
+}

--- a/cmd/gin-repod/repo_test.go
+++ b/cmd/gin-repod/repo_test.go
@@ -818,6 +818,9 @@ func Test_deleteRepoCollaborator(t *testing.T) {
 	// test valid request for existing user, existing repository, with authorization, valid delete username.
 	repoId := store.RepoId{Owner: validUser, Name: validRepoCollaborator}
 	oldShared, err := server.repos.ListSharedAccess(repoId)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	headerMap["Authorization"] = "Bearer " + token
 	url = fmt.Sprintf(urlTemplate, validUser, validRepoCollaborator, validDeleteUser)
 	_, err = RunRequest(method, url, nil, headerMap, http.StatusOK)
@@ -989,7 +992,7 @@ func Test_listRepoCommits(t *testing.T) {
 	}
 
 	// test content of resulting list of commits
-	result := []wire.CommitListItem{}
+	result := []wire.CommitSummary{}
 	err = json.Unmarshal(resp.Body.Bytes(), &result)
 	if err != nil {
 		t.Fatalf("%v\n", err)

--- a/cmd/gin-repod/routes.go
+++ b/cmd/gin-repod/routes.go
@@ -29,4 +29,5 @@ func (s *Server) SetupRoutes() {
 	r.HandleFunc("/users/{user}/repos/{repo}/objects/{object}", s.getObject).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/browse/{branch}", s.browseRepo).Methods("GET")
 	r.HandleFunc("/users/{user}/repos/{repo}/browse/{branch}/{path:.*}", s.browseRepo).Methods("GET")
+	r.HandleFunc("/users/{user}/repos/{repo}/commits/{branch}", s.listRepoCommits).Methods("GET")
 }

--- a/git/repo.go
+++ b/git/repo.go
@@ -422,18 +422,20 @@ func (repo *Repository) ParseCommitList(branch string) ([]wire.CommitListItem, e
 	return comList, nil
 }
 
-// BranchExists runs the git show-ref command. It will return
-// true, if the git command does not end with an error, false
-// in any other case.
-func (repo *Repository) BranchExists(branch string) bool {
+// BranchExists runs the "git branch <branchname> --list" command.
+// It will return an error, if the command fails, true, if the result is not empty and false otherwise.
+func (repo *Repository) BranchExists(branch string) (bool, error) {
 	gdir := fmt.Sprintf("--git-dir=%s", repo.Path)
-	ref := fmt.Sprintf("refs/heads/%s", branch)
 
-	cmd := exec.Command("git", gdir, "show-ref", ref)
-	_, err := cmd.Output()
+	cmd := exec.Command("git", gdir, "branch", branch, "--list")
+	body, err := cmd.Output()
 	if err != nil {
-		return false
+		return false, err
 	}
 
-	return true
+	if len(body) == 0 {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/git/repo.go
+++ b/git/repo.go
@@ -1,13 +1,18 @@
 package git
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/G-Node/gin-repo/wire"
 )
 
 //Repository represents an on disk git repository.
@@ -344,4 +349,83 @@ func (repo *Repository) ObjectForPath(root Object, pathstr string) (Object, erro
 	}
 
 	return node, nil
+}
+
+// parseCommitList executes a custom git log command from the branch of a
+// specified git repository and returns the resulting list of commits as an array.
+func (repo *Repository) ParseCommitList(branch string) ([]wire.CommitListItem, bool) {
+	// TODO replace fmt.Printf with proper log messages
+	// TODO do better error handling, think about returning custom errors
+
+	// execute log command for repo at repoPath
+	gdir := fmt.Sprintf("--git-dir=%s", repo.Path)
+
+	usefmt := "--pretty=format:"
+	usefmt += "Commit:=%H%n"
+	usefmt += "Committer:=%cn%n"
+	usefmt += "Author:=%an%n"
+	usefmt += "Date-iso:=%ai%n"
+	usefmt += "Date-rel:=%ar%n"
+	usefmt += "Subject:=%s%n"
+	usefmt += "Changes:="
+
+	cmd := exec.Command("git", gdir, "log", branch, usefmt, "--name-status")
+	body, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("Failed running git log: %v\n", err)
+		return nil, false
+	}
+	var comList []wire.CommitListItem
+	r := bytes.NewReader(body)
+	br := bufio.NewReader(r)
+
+	var changesFlag bool
+
+	for {
+		// Consume line until newline character
+		l, err := br.ReadString('\n')
+
+		if strings.Contains(l, ":=") {
+			splitList := strings.SplitN(l, ":=", 2)
+
+			key := splitList[0]
+			val := splitList[1]
+			switch key {
+			case "Commit":
+				// reset non key line flags
+				changesFlag = false
+				newCommit := wire.CommitListItem{Commit: val}
+				comList = append(comList, newCommit)
+			case "Committer":
+				comList[len(comList)-1].Committer = val
+			case "Author":
+				comList[len(comList)-1].Author = val
+			case "Date-iso":
+				comList[len(comList)-1].DateIso = val
+			case "Date-rel":
+				comList[len(comList)-1].DateRelative = val
+			case "Subject":
+				comList[len(comList)-1].Subject = val
+			case "Changes":
+				// Setting changes flag so we know, that the next lines are probably file change notification lines.
+				changesFlag = true
+			default:
+				fmt.Printf("Encountered unexpected key: '%s', value: '%s'\n", key, strings.Trim(val, "\n"))
+			}
+		} else if changesFlag && strings.Contains(l, "\t") {
+			comList[len(comList)-1].Changes = append(comList[len(comList)-1].Changes, l)
+		}
+
+		// Breaks at the latest when EOF err is raised
+		if err != nil {
+			break
+		}
+	}
+	if err != io.EOF && err != nil {
+		fmt.Printf("Encountered error: %v\n", err)
+		return nil, false
+	}
+	fmt.Printf("Done parsing. There where %d commits\n", len(comList))
+
+	return comList, true
 }

--- a/git/repo.go
+++ b/git/repo.go
@@ -421,3 +421,19 @@ func (repo *Repository) ParseCommitList(branch string) ([]wire.CommitListItem, e
 
 	return comList, nil
 }
+
+// BranchExists runs the git show-ref command. It will return
+// true, if the git command does not end with an error, false
+// in any other case.
+func (repo *Repository) BranchExists(branch string) bool {
+	gdir := fmt.Sprintf("--git-dir=%s", repo.Path)
+	ref := fmt.Sprintf("refs/heads/%s", branch)
+
+	cmd := exec.Command("git", gdir, "show-ref", ref)
+	_, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/git/repo.go
+++ b/git/repo.go
@@ -353,7 +353,7 @@ func (repo *Repository) ObjectForPath(root Object, pathstr string) (Object, erro
 
 // ParseCommitList executes a custom git log command of the specified branch of the
 // associated git repository and returns the resulting list of commits as an array.
-func (repo *Repository) ParseCommitList(branch string) ([]wire.CommitListItem, error) {
+func (repo *Repository) ParseCommitList(branch string) ([]wire.CommitSummary, error) {
 	gdir := fmt.Sprintf("--git-dir=%s", repo.Path)
 
 	usefmt := "--pretty=format:"
@@ -370,7 +370,7 @@ func (repo *Repository) ParseCommitList(branch string) ([]wire.CommitListItem, e
 	if err != nil {
 		return nil, fmt.Errorf("failed running git log: %s\n", err.Error())
 	}
-	var comList []wire.CommitListItem
+	var comList []wire.CommitSummary
 	r := bytes.NewReader(body)
 	br := bufio.NewReader(r)
 
@@ -388,7 +388,7 @@ func (repo *Repository) ParseCommitList(branch string) ([]wire.CommitListItem, e
 			case "Commit":
 				// reset non key line flags
 				changesFlag = false
-				newCommit := wire.CommitListItem{Commit: val}
+				newCommit := wire.CommitSummary{Commit: val}
 				comList = append(comList, newCommit)
 			case "Committer":
 				comList[len(comList)-1].Committer = val

--- a/git/repo.go
+++ b/git/repo.go
@@ -378,9 +378,7 @@ func (repo *Repository) BranchExists(branch string) (bool, error) {
 	body, err := cmd.Output()
 	if err != nil {
 		return false, err
-	}
-
-	if len(body) == 0 {
+	} else if len(body) == 0 {
 		return false, nil
 	}
 

--- a/wire/proto.go
+++ b/wire/proto.go
@@ -46,8 +46,8 @@ type RefLine struct {
 	RefName string `json:"refname"`
 }
 
-// CommitListItem represents a subset of information from a git commit
-type CommitListItem struct {
+// CommitSummary represents a subset of information from a git commit.
+type CommitSummary struct {
 	Commit       string   `json:"commit"`
 	Committer    string   `json:"committer"`
 	Author       string   `json:"author"`

--- a/wire/proto.go
+++ b/wire/proto.go
@@ -45,3 +45,14 @@ type RefLine struct {
 	NewRef  string `json:"newref"`
 	RefName string `json:"refname"`
 }
+
+// CommitListItem represents a subset of information from a git commit
+type CommitListItem struct {
+	Commit       string   `json:"commit"`
+	Committer    string   `json:"committer"`
+	Author       string   `json:"author"`
+	DateIso      string   `json:"dateiso"`
+	DateRelative string   `json:"daterel"`
+	Subject      string   `json:"subject"`
+	Changes      []string `json:"changes"`
+}


### PR DESCRIPTION
This pull request
- adds `git/repo` method `ParseCommitList` which parses and returns the results of a custom format `git log`.
- adds `git/repo` method `BranchExists` which uses `git branch <branch>` to check for branches.
- adds a repository commits REST endpoint which returns a list of commits as json.
- adds a test for the new REST endpoint.
